### PR TITLE
[Setting] #4 - Moya 네트워크 코드 세팅

### DIFF
--- a/EKO-iOS/EKO-iOS.xcodeproj/project.pbxproj
+++ b/EKO-iOS/EKO-iOS.xcodeproj/project.pbxproj
@@ -14,7 +14,6 @@
 		3D2C9E342DE5E388009DAE77 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3D2C9E332DE5E388009DAE77 /* Colors.xcassets */; };
 		3D2C9E362DE5E39A009DAE77 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 3D2C9E352DE5E39A009DAE77 /* Localizable.xcstrings */; };
 		3D2C9E382DE5F460009DAE77 /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D2C9E372DE5F460009DAE77 /* Date+.swift */; };
-		3D2C9EC52DE5F539009DAE77 /* ExampleService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D2C9EC42DE5F539009DAE77 /* ExampleService.swift */; };
 		3D2C9ECC2DE5F665009DAE77 /* LearningNoteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D2C9ECB2DE5F665009DAE77 /* LearningNoteView.swift */; };
 		3D2C9ECE2DE5F68A009DAE77 /* RecordingRequestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D2C9ECD2DE5F68A009DAE77 /* RecordingRequestView.swift */; };
 		3D2C9ED02DE5F696009DAE77 /* RecordingResponseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D2C9ECF2DE5F696009DAE77 /* RecordingResponseView.swift */; };
@@ -44,6 +43,27 @@
 		3DF325502DE74BA100F9F3F9 /* Pretendard-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 3DF3254D2DE74BA100F9F3F9 /* Pretendard-SemiBold.otf */; };
 		3DF325512DE74BA100F9F3F9 /* Pretendard-Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = 3DF3254B2DE74BA100F9F3F9 /* Pretendard-Medium.otf */; };
 		3DF325532DE74CB300F9F3F9 /* Font+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF325522DE74CB300F9F3F9 /* Font+.swift */; };
+		3DF325562DE7FC1000F9F3F9 /* CombineMoya in Frameworks */ = {isa = PBXBuildFile; productRef = 3DF325552DE7FC1000F9F3F9 /* CombineMoya */; };
+		3DF325582DE7FC1000F9F3F9 /* Moya in Frameworks */ = {isa = PBXBuildFile; productRef = 3DF325572DE7FC1000F9F3F9 /* Moya */; };
+		3DF3255A2DE7FC1000F9F3F9 /* ReactiveMoya in Frameworks */ = {isa = PBXBuildFile; productRef = 3DF325592DE7FC1000F9F3F9 /* ReactiveMoya */; };
+		3DF3255C2DE7FC1000F9F3F9 /* RxMoya in Frameworks */ = {isa = PBXBuildFile; productRef = 3DF3255B2DE7FC1000F9F3F9 /* RxMoya */; };
+		3DF3255E2DE7FDD400F9F3F9 /* BaseTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF3255D2DE7FDD400F9F3F9 /* BaseTargetType.swift */; };
+		3DF325602DE7FDE300F9F3F9 /* BaseAPIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF3255F2DE7FDE300F9F3F9 /* BaseAPIService.swift */; };
+		3DF325622DE7FDF400F9F3F9 /* NetworkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF325612DE7FDF400F9F3F9 /* NetworkResult.swift */; };
+		3DF325642DE7FDFC00F9F3F9 /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF325632DE7FDFC00F9F3F9 /* NetworkService.swift */; };
+		3DF325F42DE891A300F9F3F9 /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 3DF325F32DE891A300F9F3F9 /* Config.xcconfig */; };
+		3DF325F62DE891A900F9F3F9 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF325F52DE891A900F9F3F9 /* Config.swift */; };
+		3DF325F82DE893C700F9F3F9 /* MoyaLoggerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF325F72DE893C700F9F3F9 /* MoyaLoggerPlugin.swift */; };
+		3DF325FA2DE8943B00F9F3F9 /* MoyaProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF325F92DE8943B00F9F3F9 /* MoyaProvider.swift */; };
+		3DF326012DE8951F00F9F3F9 /* FeedbackTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF326002DE8951F00F9F3F9 /* FeedbackTargetType.swift */; };
+		3DF326032DE8953500F9F3F9 /* FeedbackAPIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF326022DE8953500F9F3F9 /* FeedbackAPIService.swift */; };
+		3DF326052DE8956300F9F3F9 /* NoteTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF326042DE8956300F9F3F9 /* NoteTargetType.swift */; };
+		3DF326072DE8959800F9F3F9 /* NoteAPIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF326062DE8959800F9F3F9 /* NoteAPIService.swift */; };
+		3DF326092DE895A400F9F3F9 /* SessionTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF326082DE895A400F9F3F9 /* SessionTargetType.swift */; };
+		3DF3260B2DE895AA00F9F3F9 /* SessionAPIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF3260A2DE895AA00F9F3F9 /* SessionAPIService.swift */; };
+		3DF3260D2DE895B100F9F3F9 /* UserTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF3260C2DE895B100F9F3F9 /* UserTargetType.swift */; };
+		3DF3260F2DE8965600F9F3F9 /* UserAPIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF3260E2DE8965600F9F3F9 /* UserAPIService.swift */; };
+		3DF326192DE9871000F9F3F9 /* FetchSendQuestionResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF326182DE9871000F9F3F9 /* FetchSendQuestionResponseDTO.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -57,7 +77,6 @@
 		3D2C9E352DE5E39A009DAE77 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		3D2C9E372DE5F460009DAE77 /* Date+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
 		3D2C9EC32DE5F4FB009DAE77 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		3D2C9EC42DE5F539009DAE77 /* ExampleService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleService.swift; sourceTree = "<group>"; };
 		3D2C9ECB2DE5F665009DAE77 /* LearningNoteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearningNoteView.swift; sourceTree = "<group>"; };
 		3D2C9ECD2DE5F68A009DAE77 /* RecordingRequestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingRequestView.swift; sourceTree = "<group>"; };
 		3D2C9ECF2DE5F696009DAE77 /* RecordingResponseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingResponseView.swift; sourceTree = "<group>"; };
@@ -88,6 +107,23 @@
 		3DF3254C2DE74BA100F9F3F9 /* Pretendard-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Regular.otf"; sourceTree = "<group>"; };
 		3DF3254D2DE74BA100F9F3F9 /* Pretendard-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-SemiBold.otf"; sourceTree = "<group>"; };
 		3DF325522DE74CB300F9F3F9 /* Font+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Font+.swift"; sourceTree = "<group>"; };
+		3DF3255D2DE7FDD400F9F3F9 /* BaseTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTargetType.swift; sourceTree = "<group>"; };
+		3DF3255F2DE7FDE300F9F3F9 /* BaseAPIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseAPIService.swift; sourceTree = "<group>"; };
+		3DF325612DE7FDF400F9F3F9 /* NetworkResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkResult.swift; sourceTree = "<group>"; };
+		3DF325632DE7FDFC00F9F3F9 /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
+		3DF325F32DE891A300F9F3F9 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
+		3DF325F52DE891A900F9F3F9 /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
+		3DF325F72DE893C700F9F3F9 /* MoyaLoggerPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoyaLoggerPlugin.swift; sourceTree = "<group>"; };
+		3DF325F92DE8943B00F9F3F9 /* MoyaProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoyaProvider.swift; sourceTree = "<group>"; };
+		3DF326002DE8951F00F9F3F9 /* FeedbackTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackTargetType.swift; sourceTree = "<group>"; };
+		3DF326022DE8953500F9F3F9 /* FeedbackAPIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackAPIService.swift; sourceTree = "<group>"; };
+		3DF326042DE8956300F9F3F9 /* NoteTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteTargetType.swift; sourceTree = "<group>"; };
+		3DF326062DE8959800F9F3F9 /* NoteAPIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteAPIService.swift; sourceTree = "<group>"; };
+		3DF326082DE895A400F9F3F9 /* SessionTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionTargetType.swift; sourceTree = "<group>"; };
+		3DF3260A2DE895AA00F9F3F9 /* SessionAPIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionAPIService.swift; sourceTree = "<group>"; };
+		3DF3260C2DE895B100F9F3F9 /* UserTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserTargetType.swift; sourceTree = "<group>"; };
+		3DF3260E2DE8965600F9F3F9 /* UserAPIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAPIService.swift; sourceTree = "<group>"; };
+		3DF326182DE9871000F9F3F9 /* FetchSendQuestionResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchSendQuestionResponseDTO.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -95,6 +131,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3DF325582DE7FC1000F9F3F9 /* Moya in Frameworks */,
+				3DF325562DE7FC1000F9F3F9 /* CombineMoya in Frameworks */,
+				3DF3255C2DE7FC1000F9F3F9 /* RxMoya in Frameworks */,
+				3DF3255A2DE7FC1000F9F3F9 /* ReactiveMoya in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -165,7 +205,11 @@
 		3D2C9E2F2DE5E1F7009DAE77 /* Network */ = {
 			isa = PBXGroup;
 			children = (
-				3D2C9EC42DE5F539009DAE77 /* ExampleService.swift */,
+				3DF325FB2DE8948800F9F3F9 /* Base */,
+				3DF325682DE7FE5700F9F3F9 /* Feedback */,
+				3DF325672DE7FE5300F9F3F9 /* Note */,
+				3DF325662DE7FE4A00F9F3F9 /* Session */,
+				3DF325652DE7FE3D00F9F3F9 /* User */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -194,6 +238,8 @@
 			children = (
 				3D2C9F112DE74AEC009DAE77 /* Fonts */,
 				3D2C9F102DE74AD5009DAE77 /* Assets */,
+				3DF325F32DE891A300F9F3F9 /* Config.xcconfig */,
+				3DF325F52DE891A900F9F3F9 /* Config.swift */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -420,6 +466,152 @@
 			path = Fonts;
 			sourceTree = "<group>";
 		};
+		3DF325652DE7FE3D00F9F3F9 /* User */ = {
+			isa = PBXGroup;
+			children = (
+				3DF325FF2DE894A900F9F3F9 /* DTO */,
+				3DF3260C2DE895B100F9F3F9 /* UserTargetType.swift */,
+				3DF3260E2DE8965600F9F3F9 /* UserAPIService.swift */,
+			);
+			path = User;
+			sourceTree = "<group>";
+		};
+		3DF325662DE7FE4A00F9F3F9 /* Session */ = {
+			isa = PBXGroup;
+			children = (
+				3DF325FE2DE894A600F9F3F9 /* DTO */,
+				3DF326082DE895A400F9F3F9 /* SessionTargetType.swift */,
+				3DF3260A2DE895AA00F9F3F9 /* SessionAPIService.swift */,
+			);
+			path = Session;
+			sourceTree = "<group>";
+		};
+		3DF325672DE7FE5300F9F3F9 /* Note */ = {
+			isa = PBXGroup;
+			children = (
+				3DF325FD2DE894A100F9F3F9 /* DTO */,
+				3DF326042DE8956300F9F3F9 /* NoteTargetType.swift */,
+				3DF326062DE8959800F9F3F9 /* NoteAPIService.swift */,
+			);
+			path = Note;
+			sourceTree = "<group>";
+		};
+		3DF325682DE7FE5700F9F3F9 /* Feedback */ = {
+			isa = PBXGroup;
+			children = (
+				3DF325FC2DE8949B00F9F3F9 /* DTO */,
+				3DF326002DE8951F00F9F3F9 /* FeedbackTargetType.swift */,
+				3DF326022DE8953500F9F3F9 /* FeedbackAPIService.swift */,
+			);
+			path = Feedback;
+			sourceTree = "<group>";
+		};
+		3DF325FB2DE8948800F9F3F9 /* Base */ = {
+			isa = PBXGroup;
+			children = (
+				3DF3255D2DE7FDD400F9F3F9 /* BaseTargetType.swift */,
+				3DF3255F2DE7FDE300F9F3F9 /* BaseAPIService.swift */,
+				3DF325612DE7FDF400F9F3F9 /* NetworkResult.swift */,
+				3DF325632DE7FDFC00F9F3F9 /* NetworkService.swift */,
+				3DF325F72DE893C700F9F3F9 /* MoyaLoggerPlugin.swift */,
+				3DF325F92DE8943B00F9F3F9 /* MoyaProvider.swift */,
+			);
+			path = Base;
+			sourceTree = "<group>";
+		};
+		3DF325FC2DE8949B00F9F3F9 /* DTO */ = {
+			isa = PBXGroup;
+			children = (
+				3DF326102DE9863E00F9F3F9 /* Request */,
+				3DF326112DE9864500F9F3F9 /* Response */,
+			);
+			path = DTO;
+			sourceTree = "<group>";
+		};
+		3DF325FD2DE894A100F9F3F9 /* DTO */ = {
+			isa = PBXGroup;
+			children = (
+				3DF326132DE9866400F9F3F9 /* Request */,
+				3DF326122DE9865F00F9F3F9 /* Response */,
+			);
+			path = DTO;
+			sourceTree = "<group>";
+		};
+		3DF325FE2DE894A600F9F3F9 /* DTO */ = {
+			isa = PBXGroup;
+			children = (
+				3DF326152DE9867800F9F3F9 /* Request */,
+				3DF326142DE9867300F9F3F9 /* Response */,
+			);
+			path = DTO;
+			sourceTree = "<group>";
+		};
+		3DF325FF2DE894A900F9F3F9 /* DTO */ = {
+			isa = PBXGroup;
+			children = (
+				3DF326172DE9867F00F9F3F9 /* Request */,
+				3DF326162DE9867C00F9F3F9 /* Response */,
+			);
+			path = DTO;
+			sourceTree = "<group>";
+		};
+		3DF326102DE9863E00F9F3F9 /* Request */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Request;
+			sourceTree = "<group>";
+		};
+		3DF326112DE9864500F9F3F9 /* Response */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Response;
+			sourceTree = "<group>";
+		};
+		3DF326122DE9865F00F9F3F9 /* Response */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Response;
+			sourceTree = "<group>";
+		};
+		3DF326132DE9866400F9F3F9 /* Request */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Request;
+			sourceTree = "<group>";
+		};
+		3DF326142DE9867300F9F3F9 /* Response */ = {
+			isa = PBXGroup;
+			children = (
+				3DF326182DE9871000F9F3F9 /* FetchSendQuestionResponseDTO.swift */,
+			);
+			path = Response;
+			sourceTree = "<group>";
+		};
+		3DF326152DE9867800F9F3F9 /* Request */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Request;
+			sourceTree = "<group>";
+		};
+		3DF326162DE9867C00F9F3F9 /* Response */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Response;
+			sourceTree = "<group>";
+		};
+		3DF326172DE9867F00F9F3F9 /* Request */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Request;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -438,6 +630,10 @@
 			);
 			name = "EKO-iOS";
 			packageProductDependencies = (
+				3DF325552DE7FC1000F9F3F9 /* CombineMoya */,
+				3DF325572DE7FC1000F9F3F9 /* Moya */,
+				3DF325592DE7FC1000F9F3F9 /* ReactiveMoya */,
+				3DF3255B2DE7FC1000F9F3F9 /* RxMoya */,
 			);
 			productName = "EKO-iOS";
 			productReference = 3D2C9E102DE5E031009DAE77 /* EKO-iOS.app */;
@@ -468,6 +664,9 @@
 			);
 			mainGroup = 3D2C9E072DE5E031009DAE77;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				3DF325542DE7FC1000F9F3F9 /* XCRemoteSwiftPackageReference "Moya" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 3D2C9E112DE5E031009DAE77 /* Products */;
 			projectDirPath = "";
@@ -487,6 +686,7 @@
 				3DF3254F2DE74BA100F9F3F9 /* Pretendard-Bold.otf in Resources */,
 				3DF325502DE74BA100F9F3F9 /* Pretendard-SemiBold.otf in Resources */,
 				3DF325512DE74BA100F9F3F9 /* Pretendard-Medium.otf in Resources */,
+				3DF325F42DE891A300F9F3F9 /* Config.xcconfig in Resources */,
 				3D2C9E342DE5E388009DAE77 /* Colors.xcassets in Resources */,
 				3D2C9E292DE5E0A0009DAE77 /* Preview Assets.xcassets in Resources */,
 				3D2C9E362DE5E39A009DAE77 /* Localizable.xcstrings in Resources */,
@@ -527,29 +727,44 @@
 				3D2C9ED82DE5F6F7009DAE77 /* RecordingResponseViewModel.swift in Sources */,
 				3D2C9ED62DE5F6E7009DAE77 /* RecordingRequestViewModel.swift in Sources */,
 				3D2C9ED42DE5F6A6009DAE77 /* AddFriendView.swift in Sources */,
+				3DF3255E2DE7FDD400F9F3F9 /* BaseTargetType.swift in Sources */,
 				3D2C9EFB2DE5FA4B009DAE77 /* ProfileSubViews.swift in Sources */,
 				3D2C9F0C2DE60FCE009DAE77 /* AppCoordinator.swift in Sources */,
 				3D2C9EF42DE5FA08009DAE77 /* LearningNoteModel.swift in Sources */,
+				3DF326012DE8951F00F9F3F9 /* FeedbackTargetType.swift in Sources */,
 				3D2C9EF22DE5F9D8009DAE77 /* MainView.swift in Sources */,
 				3D2C9ED22DE5F69E009DAE77 /* ProfileView.swift in Sources */,
 				3D2C9E382DE5F460009DAE77 /* Date+.swift in Sources */,
 				3D2C9EF62DE5FA13009DAE77 /* LearningNoteSubViews.swift in Sources */,
 				3D2C9F0A2DE60F75009DAE77 /* AppRoute.swift in Sources */,
 				3D2C9F042DE5FA85009DAE77 /* AddFriendModel.swift in Sources */,
+				3DF3260F2DE8965600F9F3F9 /* UserAPIService.swift in Sources */,
 				3D2C9F022DE5FA7F009DAE77 /* AddFriendSubViews.swift in Sources */,
 				3D2C9EE52DE5F926009DAE77 /* RecordingRequestSubView.swift in Sources */,
 				3D2C9EEC2DE5F988009DAE77 /* RecordingResponseSubView.swift in Sources */,
+				3DF3260D2DE895B100F9F3F9 /* UserTargetType.swift in Sources */,
 				3D2C9ED02DE5F696009DAE77 /* RecordingResponseView.swift in Sources */,
 				3D2C9EEA2DE5F96C009DAE77 /* RecordingResponseModel.swift in Sources */,
+				3DF326192DE9871000F9F3F9 /* FetchSendQuestionResponseDTO.swift in Sources */,
 				3D2C9ECC2DE5F665009DAE77 /* LearningNoteView.swift in Sources */,
 				3D2C9ECE2DE5F68A009DAE77 /* RecordingRequestView.swift in Sources */,
+				3DF325642DE7FDFC00F9F3F9 /* NetworkService.swift in Sources */,
 				3D2C9EDA2DE5F739009DAE77 /* LearningNoteViewModel.swift in Sources */,
+				3DF326032DE8953500F9F3F9 /* FeedbackAPIService.swift in Sources */,
+				3DF326052DE8956300F9F3F9 /* NoteTargetType.swift in Sources */,
+				3DF325622DE7FDF400F9F3F9 /* NetworkResult.swift in Sources */,
 				3DF325532DE74CB300F9F3F9 /* Font+.swift in Sources */,
-				3D2C9EC52DE5F539009DAE77 /* ExampleService.swift in Sources */,
+				3DF326072DE8959800F9F3F9 /* NoteAPIService.swift in Sources */,
+				3DF325F82DE893C700F9F3F9 /* MoyaLoggerPlugin.swift in Sources */,
+				3DF326092DE895A400F9F3F9 /* SessionTargetType.swift in Sources */,
+				3DF325F62DE891A900F9F3F9 /* Config.swift in Sources */,
 				3D2C9EFD2DE5FA53009DAE77 /* ProfileModel.swift in Sources */,
 				3D2C9EDC2DE5F743009DAE77 /* ProfileViewModel.swift in Sources */,
+				3DF325FA2DE8943B00F9F3F9 /* MoyaProvider.swift in Sources */,
 				3D2C9E2B2DE5E0A0009DAE77 /* ContentView.swift in Sources */,
 				3D2C9F0E2DE61072009DAE77 /* RootNavigationView.swift in Sources */,
+				3DF325602DE7FDE300F9F3F9 /* BaseAPIService.swift in Sources */,
+				3DF3260B2DE895AA00F9F3F9 /* SessionAPIService.swift in Sources */,
 				3D2C9E2C2DE5E0A0009DAE77 /* EKO_iOSApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -559,6 +774,7 @@
 /* Begin XCBuildConfiguration section */
 		3D2C9E1D2DE5E032009DAE77 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3DF325F32DE891A300F9F3F9 /* Config.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -621,6 +837,7 @@
 		};
 		3D2C9E1E2DE5E032009DAE77 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3DF325F32DE891A300F9F3F9 /* Config.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -675,6 +892,7 @@
 		};
 		3D2C9E202DE5E032009DAE77 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3DF325F32DE891A300F9F3F9 /* Config.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -717,6 +935,7 @@
 		};
 		3D2C9E212DE5E032009DAE77 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3DF325F32DE891A300F9F3F9 /* Config.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -779,6 +998,40 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		3DF325542DE7FC1000F9F3F9 /* XCRemoteSwiftPackageReference "Moya" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Moya/Moya.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 15.0.3;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		3DF325552DE7FC1000F9F3F9 /* CombineMoya */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3DF325542DE7FC1000F9F3F9 /* XCRemoteSwiftPackageReference "Moya" */;
+			productName = CombineMoya;
+		};
+		3DF325572DE7FC1000F9F3F9 /* Moya */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3DF325542DE7FC1000F9F3F9 /* XCRemoteSwiftPackageReference "Moya" */;
+			productName = Moya;
+		};
+		3DF325592DE7FC1000F9F3F9 /* ReactiveMoya */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3DF325542DE7FC1000F9F3F9 /* XCRemoteSwiftPackageReference "Moya" */;
+			productName = ReactiveMoya;
+		};
+		3DF3255B2DE7FC1000F9F3F9 /* RxMoya */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3DF325542DE7FC1000F9F3F9 /* XCRemoteSwiftPackageReference "Moya" */;
+			productName = RxMoya;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 3D2C9E082DE5E031009DAE77 /* Project object */;
 }

--- a/EKO-iOS/EKO-iOS.xcodeproj/project.pbxproj
+++ b/EKO-iOS/EKO-iOS.xcodeproj/project.pbxproj
@@ -64,6 +64,10 @@
 		3DF3260D2DE895B100F9F3F9 /* UserTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF3260C2DE895B100F9F3F9 /* UserTargetType.swift */; };
 		3DF3260F2DE8965600F9F3F9 /* UserAPIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF3260E2DE8965600F9F3F9 /* UserAPIService.swift */; };
 		3DF326192DE9871000F9F3F9 /* FetchSendQuestionResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF326182DE9871000F9F3F9 /* FetchSendQuestionResponseDTO.swift */; };
+		3DF3272F2DE9A8DC00F9F3F9 /* PostStartQuestionResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF3272E2DE9A8DC00F9F3F9 /* PostStartQuestionResponseDTO.swift */; };
+		3DF327352DE9A9E400F9F3F9 /* NotificationTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF327342DE9A9E400F9F3F9 /* NotificationTargetType.swift */; };
+		3DF327372DE9A9EE00F9F3F9 /* NotificationAPIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF327362DE9A9EE00F9F3F9 /* NotificationAPIService.swift */; };
+		3DF327392DE9AA3F00F9F3F9 /* PostStartQuestionRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF327382DE9AA3F00F9F3F9 /* PostStartQuestionRequestDTO.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -124,6 +128,10 @@
 		3DF3260C2DE895B100F9F3F9 /* UserTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserTargetType.swift; sourceTree = "<group>"; };
 		3DF3260E2DE8965600F9F3F9 /* UserAPIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAPIService.swift; sourceTree = "<group>"; };
 		3DF326182DE9871000F9F3F9 /* FetchSendQuestionResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchSendQuestionResponseDTO.swift; sourceTree = "<group>"; };
+		3DF3272E2DE9A8DC00F9F3F9 /* PostStartQuestionResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostStartQuestionResponseDTO.swift; sourceTree = "<group>"; };
+		3DF327342DE9A9E400F9F3F9 /* NotificationTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationTargetType.swift; sourceTree = "<group>"; };
+		3DF327362DE9A9EE00F9F3F9 /* NotificationAPIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationAPIService.swift; sourceTree = "<group>"; };
+		3DF327382DE9AA3F00F9F3F9 /* PostStartQuestionRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostStartQuestionRequestDTO.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -208,6 +216,7 @@
 				3DF325FB2DE8948800F9F3F9 /* Base */,
 				3DF325682DE7FE5700F9F3F9 /* Feedback */,
 				3DF325672DE7FE5300F9F3F9 /* Note */,
+				3DF327302DE9A98800F9F3F9 /* Notification */,
 				3DF325662DE7FE4A00F9F3F9 /* Session */,
 				3DF325652DE7FE3D00F9F3F9 /* User */,
 			);
@@ -587,6 +596,7 @@
 			isa = PBXGroup;
 			children = (
 				3DF326182DE9871000F9F3F9 /* FetchSendQuestionResponseDTO.swift */,
+				3DF3272E2DE9A8DC00F9F3F9 /* PostStartQuestionResponseDTO.swift */,
 			);
 			path = Response;
 			sourceTree = "<group>";
@@ -594,6 +604,7 @@
 		3DF326152DE9867800F9F3F9 /* Request */ = {
 			isa = PBXGroup;
 			children = (
+				3DF327382DE9AA3F00F9F3F9 /* PostStartQuestionRequestDTO.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -606,6 +617,39 @@
 			sourceTree = "<group>";
 		};
 		3DF326172DE9867F00F9F3F9 /* Request */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Request;
+			sourceTree = "<group>";
+		};
+		3DF327302DE9A98800F9F3F9 /* Notification */ = {
+			isa = PBXGroup;
+			children = (
+				3DF327312DE9A9CB00F9F3F9 /* DTO */,
+				3DF327342DE9A9E400F9F3F9 /* NotificationTargetType.swift */,
+				3DF327362DE9A9EE00F9F3F9 /* NotificationAPIService.swift */,
+			);
+			path = Notification;
+			sourceTree = "<group>";
+		};
+		3DF327312DE9A9CB00F9F3F9 /* DTO */ = {
+			isa = PBXGroup;
+			children = (
+				3DF327332DE9A9D700F9F3F9 /* Request */,
+				3DF327322DE9A9D200F9F3F9 /* Response */,
+			);
+			path = DTO;
+			sourceTree = "<group>";
+		};
+		3DF327322DE9A9D200F9F3F9 /* Response */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Response;
+			sourceTree = "<group>";
+		};
+		3DF327332DE9A9D700F9F3F9 /* Request */ = {
 			isa = PBXGroup;
 			children = (
 			);
@@ -730,12 +774,14 @@
 				3DF3255E2DE7FDD400F9F3F9 /* BaseTargetType.swift in Sources */,
 				3D2C9EFB2DE5FA4B009DAE77 /* ProfileSubViews.swift in Sources */,
 				3D2C9F0C2DE60FCE009DAE77 /* AppCoordinator.swift in Sources */,
+				3DF3272F2DE9A8DC00F9F3F9 /* PostStartQuestionResponseDTO.swift in Sources */,
 				3D2C9EF42DE5FA08009DAE77 /* LearningNoteModel.swift in Sources */,
 				3DF326012DE8951F00F9F3F9 /* FeedbackTargetType.swift in Sources */,
 				3D2C9EF22DE5F9D8009DAE77 /* MainView.swift in Sources */,
 				3D2C9ED22DE5F69E009DAE77 /* ProfileView.swift in Sources */,
 				3D2C9E382DE5F460009DAE77 /* Date+.swift in Sources */,
 				3D2C9EF62DE5FA13009DAE77 /* LearningNoteSubViews.swift in Sources */,
+				3DF327372DE9A9EE00F9F3F9 /* NotificationAPIService.swift in Sources */,
 				3D2C9F0A2DE60F75009DAE77 /* AppRoute.swift in Sources */,
 				3D2C9F042DE5FA85009DAE77 /* AddFriendModel.swift in Sources */,
 				3DF3260F2DE8965600F9F3F9 /* UserAPIService.swift in Sources */,
@@ -744,6 +790,8 @@
 				3D2C9EEC2DE5F988009DAE77 /* RecordingResponseSubView.swift in Sources */,
 				3DF3260D2DE895B100F9F3F9 /* UserTargetType.swift in Sources */,
 				3D2C9ED02DE5F696009DAE77 /* RecordingResponseView.swift in Sources */,
+				3DF327392DE9AA3F00F9F3F9 /* PostStartQuestionRequestDTO.swift in Sources */,
+				3DF327352DE9A9E400F9F3F9 /* NotificationTargetType.swift in Sources */,
 				3D2C9EEA2DE5F96C009DAE77 /* RecordingResponseModel.swift in Sources */,
 				3DF326192DE9871000F9F3F9 /* FetchSendQuestionResponseDTO.swift in Sources */,
 				3D2C9ECC2DE5F665009DAE77 /* LearningNoteView.swift in Sources */,

--- a/EKO-iOS/EKO-iOS/Core/Resources/Config.swift
+++ b/EKO-iOS/EKO-iOS/Core/Resources/Config.swift
@@ -1,0 +1,30 @@
+//
+//  Config.swift
+//  EKO-iOS
+//
+//  Created by mini on 5/29/25.
+//
+
+import Foundation
+
+enum Config {
+    enum Network {
+        static let baseURL = "BASE_URL"
+    }
+    
+    private static let infoDictionary: [String: Any] = {
+        guard let dict = Bundle.main.infoDictionary else {
+            fatalError("plist cannot found.")
+        }
+        return dict
+    }()
+}
+
+extension Config {
+    static let baseURL: String = {
+        guard let key = Config.infoDictionary[Network.baseURL] as? String else {
+            fatalError("⛔️BASE_URL is not set in plist for this configuration⛔️")
+        }
+        return key
+    }()
+}

--- a/EKO-iOS/EKO-iOS/Core/Supporting Files/Info.plist
+++ b/EKO-iOS/EKO-iOS/Core/Supporting Files/Info.plist
@@ -2,6 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>BASE_URL</key>
+	<string>$(BASE_URL)</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Pretendard-Bold.otf</string>
@@ -9,10 +16,5 @@
 		<string>Pretendard-Medium.otf</string>
 		<string>Pretendard-Regular.otf</string>
 	</array>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-	</dict>
 </dict>
 </plist>

--- a/EKO-iOS/EKO-iOS/Network/Base/BaseAPIService.swift
+++ b/EKO-iOS/EKO-iOS/Network/Base/BaseAPIService.swift
@@ -1,0 +1,50 @@
+//
+//  BaseAPIService.swift
+//  EKO-iOS
+//
+//  Created by mini on 5/29/25.
+//
+
+import Foundation
+import Moya
+
+class BaseAPIService<Target: TargetType> {
+    
+    /// 200 받았을 때 decoding 할 데이터가 존재하는 경우 (대부분의 GET)
+    func fetchNetworkResult<T: Decodable>(statusCode: Int, data: Data) -> NetworkResult<T> {
+        switch statusCode {
+        case 200, 201, 204:
+            if let decodedData = fetchDecodeData(data: data, responseType: T.self) {
+                return .success(decodedData)
+            } else { return .decodeErr }
+        case 400: return .badRequest
+        case 401: return .unAuthorized
+        case 404: return .notFound
+        case 422: return .unProcessable
+        case 500: return .serverErr
+        default: return .networkFail
+        }
+    }
+    
+    /// 200 받았을 때 decoding 할 데이터가 없는 경우 (대부분의 PATCH, PUT, DELETE)
+    func fetchNetworkResult(statusCode: Int, data: Data) -> NetworkResult<Any> {
+        switch statusCode {
+        case 200, 201, 204: return .success(nil)
+        case 400: return .badRequest
+        case 401: return .unAuthorized
+        case 404: return .notFound
+        case 422: return .unProcessable
+        case 500: return .serverErr
+        default: return .networkFail
+        }
+    }
+    
+    /// API를 통해 받아온 Data를 T Type 형태로 Decode하는 함수
+    func fetchDecodeData<T: Decodable>(data: Data, responseType: T.Type) -> T? {
+        let decoder = JSONDecoder()
+        
+        if let decodedData = try? decoder.decode(responseType, from: data) {
+            return decodedData
+        } else { return nil }
+    }
+}

--- a/EKO-iOS/EKO-iOS/Network/Base/BaseTargetType.swift
+++ b/EKO-iOS/EKO-iOS/Network/Base/BaseTargetType.swift
@@ -11,7 +11,7 @@ import Moya
 enum UtilPath: String {
     case feedback = "feedback"
     case note = "note"
-    case session = "session"
+    case session = "sessions"
     case user = "user"
 }
 

--- a/EKO-iOS/EKO-iOS/Network/Base/BaseTargetType.swift
+++ b/EKO-iOS/EKO-iOS/Network/Base/BaseTargetType.swift
@@ -10,9 +10,10 @@ import Moya
 
 enum UtilPath: String {
     case feedback = "feedback"
-    case note = "note"
+    case note = "notes"
+    case notification = "notifications"
     case session = "sessions"
-    case user = "user"
+    case user = "users"
 }
 
 protocol BaseTargetType: TargetType {
@@ -32,16 +33,6 @@ extension BaseTargetType {
         
     var headers: [String: String]? {
         return ["Content-Type": "application/json"]
-    }
-    
-    var task: Task {
-        if let queryParameter {
-            return .requestParameters(parameters: queryParameter, encoding: URLEncoding.default)
-        }
-        if let requestBodyParameter {
-            return .requestJSONEncodable(requestBodyParameter)
-        }
-        return .requestPlain
     }
     
     var sampleData: Data {

--- a/EKO-iOS/EKO-iOS/Network/Base/BaseTargetType.swift
+++ b/EKO-iOS/EKO-iOS/Network/Base/BaseTargetType.swift
@@ -1,0 +1,54 @@
+//
+//  BaseTargetType.swift
+//  EKO-iOS
+//
+//  Created by mini on 5/29/25.
+//
+
+import Foundation
+import Moya
+
+enum UtilPath: String {
+    case feedback = "feedback"
+    case note = "note"
+    case session = "session"
+    case user = "user"
+}
+
+protocol BaseTargetType: TargetType {
+    var utilPath: UtilPath { get }
+    var pathParameter: String? { get }
+    var queryParameter: [String: Any]? { get }
+    var requestBodyParameter: Codable? { get }
+}
+
+extension BaseTargetType {
+    var baseURL: URL {
+        guard let baseURL = URL(string: Config.baseURL) else {
+            fatalError("🍞⛔️ Base URL이 없어요! ⛔️🍞")
+        }
+        return baseURL
+    }
+        
+    var headers: [String: String]? {
+        return ["Content-Type": "application/json"]
+    }
+    
+    var task: Task {
+        if let queryParameter {
+            return .requestParameters(parameters: queryParameter, encoding: URLEncoding.default)
+        }
+        if let requestBodyParameter {
+            return .requestJSONEncodable(requestBodyParameter)
+        }
+        return .requestPlain
+    }
+    
+    var sampleData: Data {
+        return Data()
+    }
+    
+    var validationType: ValidationType {
+        return .successCodes
+    }
+}

--- a/EKO-iOS/EKO-iOS/Network/Base/MoyaLoggerPlugin.swift
+++ b/EKO-iOS/EKO-iOS/Network/Base/MoyaLoggerPlugin.swift
@@ -1,0 +1,80 @@
+//
+//  MoyaLoggerPlugin.swift
+//  EKO-iOS
+//
+//  Created by mini on 5/29/25.
+//
+
+import Foundation
+import Moya
+import UIKit
+
+// MoyaLoggerPlugin : 발생하는 모든 네트워크 작업을 콘솔에 기록해주기 위함
+
+final class MoyaLoggerPlugin: PluginType {
+    // Request를 보낼 때 호출
+    func willSend(_ request: RequestType, target: TargetType) {
+        guard let httpRequest = request.request else {
+            print("--> 유효하지 않은 요청")
+            return
+        }
+        let url = httpRequest.description
+        let method = httpRequest.httpMethod ?? "unknown method"
+        var log = "----------------------------------------------------\n[\(method)] \(url)\n----------------------------------------------------\n"
+        log.append("API: \(target)\n")
+        if let headers = httpRequest.allHTTPHeaderFields, !headers.isEmpty {
+            log.append("header: \(headers)\n")
+        }
+        if let body = httpRequest.httpBody, let bodyString = String(bytes: body, encoding: String.Encoding.utf8) {
+            log.append("\(bodyString)\n")
+        }
+        log.append("------------------- END \(method) --------------------------")
+        print(log)
+    }
+    
+    // Response가 왔을 때 호출
+    func didReceive(_ result: Result<Response, MoyaError>, target: TargetType) {
+        switch result {
+        case let .success(response):
+            onSuceed(response, target: target, isFromError: false)
+        case let .failure(error):
+            onFail(error, target: target)
+        }
+    }
+    
+    // Network 통신이 성공했을 때 호출
+    func onSuceed(_ response: Response, target: TargetType, isFromError: Bool) {
+        let request = response.request
+        let url = request?.url?.absoluteString ?? "nil"
+        let statusCode = response.statusCode
+        
+        var log = "------------------- 네트워크 통신 성공(isFromError: \(isFromError)) -------------------"
+        log.append("\n[\(statusCode)] \(url)\n----------------------------------------------------\n")
+        log.append("API: \(target)\n")
+        response.response?.allHeaderFields.forEach {
+            log.append("\($0): \($1)\n")
+        }
+        if let reString = String(bytes: response.data, encoding: String.Encoding.utf8) {
+            log.append("\(reString)\n")
+        }
+        log.append("------------------- END HTTP (\(response.data.count)-byte body) -------------------")
+        print(log)
+    }
+    
+    // Network 통신이 실패했을 때 호출
+    func onFail(_ error: MoyaError, target: TargetType) {
+        if let response = error.response {
+            onSuceed(response, target: target, isFromError: true)
+            return
+        }
+        var log = "네트워크 오류"
+        log.append("<-- \(error.errorCode) \(target)\n")
+        log.append("\(error.failureReason ?? error.errorDescription ?? "unknown error")\n")
+        log.append("<-- END HTTP")
+        print(log)
+        
+        let alertViewController = UIAlertController(title: "네트워크 연결 실패", message: "네트워크 환경을 한번 더 확인해주세요.", preferredStyle: .alert)
+        alertViewController.addAction(UIAlertAction(title: "확인", style: .default, handler: nil))
+        
+    }
+}

--- a/EKO-iOS/EKO-iOS/Network/Base/MoyaProvider.swift
+++ b/EKO-iOS/EKO-iOS/Network/Base/MoyaProvider.swift
@@ -1,0 +1,24 @@
+//
+//  MoyaProvider.swift
+//  EKO-iOS
+//
+//  Created by mini on 5/29/25.
+//
+
+import Foundation
+import Moya
+
+extension MoyaProvider {
+    func request(_ target: Target) async throws -> Response {
+        try await withCheckedThrowingContinuation { continuation in
+            self.request(target) { result in
+                switch result {
+                case .success(let response):    // 성공
+                    continuation.resume(returning: response)
+                case .failure(let error):       // 실패
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+}

--- a/EKO-iOS/EKO-iOS/Network/Base/NetworkResult.swift
+++ b/EKO-iOS/EKO-iOS/Network/Base/NetworkResult.swift
@@ -1,0 +1,37 @@
+//
+//  NetworkResult.swift
+//  EKO-iOS
+//
+//  Created by mini on 5/29/25.
+//
+
+import Foundation
+
+enum NetworkResult<T>: Error {
+    
+    case success(T?)
+    
+    case networkFail        // 네트워크 연결 실패했을 때
+    case decodeErr          // 데이터는 받아왔으나 DTO 형식으로 decode가 되지 않을 때
+    
+    case badRequest         // BAD REQUEST EXCEPTION (400)
+    case unAuthorized       // UNAUTHORIZED EXCEPTION (401)
+    case notFound           // NOT FOUND (404)
+    case unProcessable      // UNPROCESSABLE_ENTITY (422)
+    case serverErr          // INTERNAL_SERVER_ERROR (500번대)
+    
+    var stateDescription: String {
+        switch self {
+        case .success: return "📢📢📢 SUCCESS 📢📢📢"
+
+        case .networkFail: return "🔥 NETWORK FAIL 🔥"
+        case .decodeErr: return "🔥 DECODED_ERROR 🔥"
+            
+        case .badRequest: return "🔥 BAD REQUEST EXCEPTION 🔥"
+        case .unAuthorized: return "🔥 UNAUTHORIZED EXCEPTION 🔥"
+        case .notFound: return "🔥 NOT FOUND 🔥"
+        case .unProcessable: return "🔥 UNPROCESSABLE ENTITY 🔥"
+        case .serverErr: return "🔥 INTERNAL SERVER_ERROR 🔥"
+        }
+    }
+}

--- a/EKO-iOS/EKO-iOS/Network/Base/NetworkService.swift
+++ b/EKO-iOS/EKO-iOS/Network/Base/NetworkService.swift
@@ -1,0 +1,20 @@
+//
+//  NetworkService.swift
+//  EKO-iOS
+//
+//  Created by mini on 5/29/25.
+//
+
+import Foundation
+
+final class NetworkService {
+    
+    static let shared = NetworkService()
+
+    private init() {}
+    
+    //let feedbackService: FeedbackAPIServiceProtocol = SessionAPIService()
+    //let noteService: SessionAPIServiceProtocol = SessionAPIService()
+    let sessionService: SessionAPIServiceProtocol = SessionAPIService()
+    //let userService: SessionAPIServiceProtocol = SessionAPIService()
+}

--- a/EKO-iOS/EKO-iOS/Network/Base/NetworkService.swift
+++ b/EKO-iOS/EKO-iOS/Network/Base/NetworkService.swift
@@ -13,8 +13,9 @@ final class NetworkService {
 
     private init() {}
     
-    //let feedbackService: FeedbackAPIServiceProtocol = SessionAPIService()
-    //let noteService: SessionAPIServiceProtocol = SessionAPIService()
+    //let feedbackService: FeedbackAPIServiceProtocol = FeedbackAPIService()
+    //let noteService: SessionAPIServiceProtocol = NoteAPIService()
+    //let notificationService: SessionAPIServiceProtocol = NotificationAPIService()
     let sessionService: SessionAPIServiceProtocol = SessionAPIService()
-    //let userService: SessionAPIServiceProtocol = SessionAPIService()
+    //let userService: SessionAPIServiceProtocol = UserAPIService()
 }

--- a/EKO-iOS/EKO-iOS/Network/ExampleService.swift
+++ b/EKO-iOS/EKO-iOS/Network/ExampleService.swift
@@ -1,8 +1,0 @@
-//
-//  ExampleService.swift
-//  EKO-iOS
-//
-//  Created by mini on 5/27/25.
-//
-
-import Foundation

--- a/EKO-iOS/EKO-iOS/Network/Feedback/FeedbackAPIService.swift
+++ b/EKO-iOS/EKO-iOS/Network/Feedback/FeedbackAPIService.swift
@@ -1,0 +1,8 @@
+//
+//  FeedbackAPIService.swift
+//  EKO-iOS
+//
+//  Created by mini on 5/29/25.
+//
+
+import Foundation

--- a/EKO-iOS/EKO-iOS/Network/Feedback/FeedbackTargetType.swift
+++ b/EKO-iOS/EKO-iOS/Network/Feedback/FeedbackTargetType.swift
@@ -1,0 +1,8 @@
+//
+//  FeedbackTargetType.swift
+//  EKO-iOS
+//
+//  Created by mini on 5/29/25.
+//
+
+import Foundation

--- a/EKO-iOS/EKO-iOS/Network/Note/NoteAPIService.swift
+++ b/EKO-iOS/EKO-iOS/Network/Note/NoteAPIService.swift
@@ -1,0 +1,8 @@
+//
+//  NoteAPIService.swift
+//  EKO-iOS
+//
+//  Created by mini on 5/29/25.
+//
+
+import Foundation

--- a/EKO-iOS/EKO-iOS/Network/Note/NoteTargetType.swift
+++ b/EKO-iOS/EKO-iOS/Network/Note/NoteTargetType.swift
@@ -1,0 +1,8 @@
+//
+//  NoteTargetType.swift
+//  EKO-iOS
+//
+//  Created by mini on 5/29/25.
+//
+
+import Foundation

--- a/EKO-iOS/EKO-iOS/Network/Notification/NotificationAPIService.swift
+++ b/EKO-iOS/EKO-iOS/Network/Notification/NotificationAPIService.swift
@@ -1,0 +1,8 @@
+//
+//  NotificationAPIService.swift
+//  EKO-iOS
+//
+//  Created by mini on 5/30/25.
+//
+
+import Foundation

--- a/EKO-iOS/EKO-iOS/Network/Notification/NotificationTargetType.swift
+++ b/EKO-iOS/EKO-iOS/Network/Notification/NotificationTargetType.swift
@@ -1,0 +1,8 @@
+//
+//  NotificationTargetType.swift
+//  EKO-iOS
+//
+//  Created by mini on 5/30/25.
+//
+
+import Foundation

--- a/EKO-iOS/EKO-iOS/Network/Session/DTO/Request/PostStartQuestionRequestDTO.swift
+++ b/EKO-iOS/EKO-iOS/Network/Session/DTO/Request/PostStartQuestionRequestDTO.swift
@@ -1,0 +1,14 @@
+//
+//  PostStartQuestionRequestDTO.swift
+//  EKO-iOS
+//
+//  Created by mini on 5/30/25.
+//
+
+import Foundation
+
+struct PostStartQuestionRequestDTO: Decodable {
+    let senderUserId: String
+    let receiverUserId: String
+    let audioFileURL: URL
+}

--- a/EKO-iOS/EKO-iOS/Network/Session/DTO/Request/PostStartQuestionRequestDTO.swift
+++ b/EKO-iOS/EKO-iOS/Network/Session/DTO/Request/PostStartQuestionRequestDTO.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct PostStartQuestionRequestDTO: Decodable {
+struct PostStartQuestionRequestDTO: Encodable {
     let senderUserId: String
     let receiverUserId: String
     let audioFileURL: URL

--- a/EKO-iOS/EKO-iOS/Network/Session/DTO/Response/FetchSendQuestionResponseDTO.swift
+++ b/EKO-iOS/EKO-iOS/Network/Session/DTO/Response/FetchSendQuestionResponseDTO.swift
@@ -1,0 +1,22 @@
+//
+//  FetchSendQuestionResponseDTO.swift
+//  EKO-iOS
+//
+//  Created by mini on 5/30/25.
+//
+
+import Foundation
+
+struct FetchSendQuestionResponseDTO: Decodable {
+    let sessions: [Session]
+}
+
+struct Session: Decodable {
+    let receiverUserId: String
+    let sessionId: String
+    let status: String
+    let createdAt: Int
+    let senderUserId: String
+    let s3Key: String
+    let title: String
+}

--- a/EKO-iOS/EKO-iOS/Network/Session/DTO/Response/PostStartQuestionResponseDTO.swift
+++ b/EKO-iOS/EKO-iOS/Network/Session/DTO/Response/PostStartQuestionResponseDTO.swift
@@ -1,0 +1,14 @@
+//
+//  PostStartQuestionResponseDTO.swift
+//  EKO-iOS
+//
+//  Created by mini on 5/30/25.
+//
+
+import Foundation
+
+struct PostStartQuestionResponseDTO: Decodable {
+    let success: Bool
+    let sessionId: String
+    let s3Key: String
+}

--- a/EKO-iOS/EKO-iOS/Network/Session/SessionAPIService.swift
+++ b/EKO-iOS/EKO-iOS/Network/Session/SessionAPIService.swift
@@ -1,0 +1,33 @@
+//
+//  SessionAPIService.swift
+//  EKO-iOS
+//
+//  Created by mini on 5/29/25.
+//
+
+import Foundation
+import Moya
+
+protocol SessionAPIServiceProtocol {
+    func fetchSendQuestion(senderUserId: String) async throws -> [FetchSendQuestionResponseDTO]
+}
+
+final class SessionAPIService: BaseAPIService<SessionTargetType>, SessionAPIServiceProtocol {
+    private let provider = MoyaProvider<SessionTargetType>(plugins: [MoyaLoggerPlugin()])
+    
+    func fetchSendQuestion(senderUserId: String) async throws -> [FetchSendQuestionResponseDTO] {
+        let response = try await provider.request(.fetchSendQuestion(senderUserId: senderUserId))
+        let result: NetworkResult<[FetchSendQuestionResponseDTO]> = fetchNetworkResult(
+            statusCode: response.statusCode,
+            data: response.data
+        )
+        switch result {
+        case .success(let data):
+            guard let data else { throw NetworkResult<Error>.decodeErr }
+            return data
+        default:
+            throw NetworkResult<Error>.decodeErr
+        }
+
+    }
+}

--- a/EKO-iOS/EKO-iOS/Network/Session/SessionAPIService.swift
+++ b/EKO-iOS/EKO-iOS/Network/Session/SessionAPIService.swift
@@ -10,9 +10,11 @@ import Moya
 
 protocol SessionAPIServiceProtocol {
     func fetchSendQuestion(senderUserId: String) async throws -> [FetchSendQuestionResponseDTO]
+    func postStartQuestion(model: PostStartQuestionRequestDTO) async throws -> [PostStartQuestionResponseDTO]
 }
 
 final class SessionAPIService: BaseAPIService<SessionTargetType>, SessionAPIServiceProtocol {
+    
     private let provider = MoyaProvider<SessionTargetType>(plugins: [MoyaLoggerPlugin()])
     
     func fetchSendQuestion(senderUserId: String) async throws -> [FetchSendQuestionResponseDTO] {
@@ -26,8 +28,22 @@ final class SessionAPIService: BaseAPIService<SessionTargetType>, SessionAPIServ
             guard let data else { throw NetworkResult<Error>.decodeErr }
             return data
         default:
-            throw NetworkResult<Error>.decodeErr
+            throw NetworkResult<Error>.networkFail
         }
-
+    }
+    
+    func postStartQuestion(model: PostStartQuestionRequestDTO) async throws -> [PostStartQuestionResponseDTO] {
+        let response = try await provider.request(.postStartQuestion(model: model))
+        let result: NetworkResult<[PostStartQuestionResponseDTO]> = fetchNetworkResult(
+            statusCode: response.statusCode,
+            data: response.data
+        )
+        switch result {
+        case .success(let data):
+            guard let data else { throw NetworkResult<Error>.decodeErr }
+            return data
+        default:
+            throw NetworkResult<Error>.networkFail
+        }
     }
 }

--- a/EKO-iOS/EKO-iOS/Network/Session/SessionTargetType.swift
+++ b/EKO-iOS/EKO-iOS/Network/Session/SessionTargetType.swift
@@ -1,0 +1,50 @@
+//
+//  SessionTargetType.swift
+//  EKO-iOS
+//
+//  Created by mini on 5/29/25.
+//
+
+import Foundation
+import Moya
+
+enum SessionTargetType {
+    case fetchSendQuestion(senderUserId: String)
+    case postQuestionStarted
+}
+
+extension SessionTargetType: BaseTargetType {
+    var headerType: [String: String]? { return ["Content-Type": "application/json"] }
+    var utilPath: UtilPath { .user }
+    var pathParameter: String? { .none }
+    
+    var queryParameter: [String: Any]? {
+        switch self {
+        case .fetchSendQuestion(let senderUserId):
+            return ["senderUserId": senderUserId]
+        default:
+            return .none
+        }
+    }
+    
+    var requestBodyParameter: Codable? {
+        switch self {
+        case .fetchSendQuestion: return .none
+        default: return .none
+        }
+    }
+    
+    var path: String {
+        switch self {
+        case .fetchSendQuestion: return utilPath.rawValue
+        case .postQuestionStarted: return utilPath.rawValue + "/start"
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .fetchSendQuestion: return .get
+        case .postQuestionStarted: return .post
+        }
+    }
+}

--- a/EKO-iOS/EKO-iOS/Network/Session/SessionTargetType.swift
+++ b/EKO-iOS/EKO-iOS/Network/Session/SessionTargetType.swift
@@ -15,8 +15,8 @@ enum SessionTargetType {
 
 extension SessionTargetType: BaseTargetType {
     var headerType: [String: String]? { return ["Content-Type": "application/json"] }
-    var utilPath: UtilPath { .user }
-    var pathParameter: String? { .none }
+    var utilPath: UtilPath { return .session }
+    var pathParameter: String? { return .none }
     
     var queryParameter: [String: Any]? {
         switch self {

--- a/EKO-iOS/EKO-iOS/Network/User/UserAPIService.swift
+++ b/EKO-iOS/EKO-iOS/Network/User/UserAPIService.swift
@@ -1,0 +1,8 @@
+//
+//  UserAPIService.swift
+//  EKO-iOS
+//
+//  Created by mini on 5/29/25.
+//
+
+import Foundation

--- a/EKO-iOS/EKO-iOS/Network/User/UserTargetType.swift
+++ b/EKO-iOS/EKO-iOS/Network/User/UserTargetType.swift
@@ -1,0 +1,8 @@
+//
+//  UserTargetType.swift
+//  EKO-iOS
+//
+//  Created by mini on 5/29/25.
+//
+
+import Foundation


### PR DESCRIPTION
## ✨ 해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #4 

## 🔍 PR Content
<!-- 작업 내용 설명 -->
네트워크 작업을 할 수 있는 기본 틀 (Moya 사용)을 구현했습니다.

- Config BASE_URL 설정
- 네트워크 부모 코드 구현 : BaseTargetType, BaseAPIService, NetworkResult, NetworkService, MoyaLoggerPlugin, MoyaProvider
  - `BaseTargetType` 공통적인 API 구성요소를 추상화한 상위 모듈 (baseURL 주소, header 등을 정의하고 있음).
  - `BaseAPIService` decode를 위한 메서드들을 가장 상위에서 추상화하고 있는 모듈
  - `NetworkResult` 네트워크 요청 결과를 정의하고 있는 열거형 (enum) 타입
  - `NetworkService` 싱글톤 객체. 각 View 혹은 ViewModel에서 네트워크 메서드를 호출할 때 해당 객체를 활용
    ```Swift
    // 예시
    NetworkService.shared.sessionService.fetchSendQuestion(senderUserId: String)
    ```
  - `MoyaLoggerPlugin` 네트워크 요청/응답을 로그로 출력하는 역할. 손댈것 없음! 그냥 자동으로 찍혀서 나오는 애임!
  - `MoyaProvider` 위에서 정의한 TargetType을 기반으로 실제 네트워크 요청을 수행하는 애

- sessions 도메인 네트워크 메서드 두개 (보낸 질문 조회-GET, 질문 시작-POST) 구현
  - `fetchSendQuestion(senderUserId:)` : 보낸 질문 조회 (참고로 GET 통신은 함수 이름을 fetch~로 보통 짓습니다. (get~은 쓰지 않음)
  - `postStartQuestion(model:)` : 질문 시작


## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
