### PR TITLE
[Feat] #17 - 네트워크 API 로직 구현

### DIFF
--- a/EKO-iOS/DeleteFeedbackNoteRequestDTO.swift
+++ b/EKO-iOS/DeleteFeedbackNoteRequestDTO.swift
@@ -1,0 +1,12 @@
+//
+//  DeleteFeedbackNoteRequestDTO.swift
+//  EKO-iOS
+//
+//  Created by 성현 on 5/31/25.
+//
+
+import Foundation
+
+struct DeleteFeedbackNoteRequestDTO: Encodable {
+    let sessionId: String
+}

--- a/EKO-iOS/DeleteFeedbackNoteResponseDTO.swift
+++ b/EKO-iOS/DeleteFeedbackNoteResponseDTO.swift
@@ -1,0 +1,14 @@
+//
+//  DeleteFeedbackNoteResponseDTO.swift
+//  EKO-iOS
+//
+//  Created by 성현 on 5/31/25.
+//
+
+import Foundation
+
+struct DeleteFeedbackNoteResponseDTO: Decodable {
+    let message: String
+    let sessionId: String
+}
+

--- a/EKO-iOS/EKO-iOS.xcodeproj/project.pbxproj
+++ b/EKO-iOS/EKO-iOS.xcodeproj/project.pbxproj
@@ -135,7 +135,6 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-
 		0F49DC812DE741DC007C15C7 /* Utils */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = Utils;
@@ -983,7 +982,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.2;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "TeamTwoUs.EKO-iOS.EKO-iOS";
+				PRODUCT_BUNDLE_IDENTIFIER = "Team.TwoUs.EKO-iOS.EKO-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = auto;
@@ -1027,7 +1026,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.2;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "TeamTwoUs.EKO-iOS.EKO-iOS";
+				PRODUCT_BUNDLE_IDENTIFIER = "Team.TwoUs.EKO-iOS.EKO-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = auto;

--- a/EKO-iOS/EKO-iOS/Network/Base/BaseTargetType.swift
+++ b/EKO-iOS/EKO-iOS/Network/Base/BaseTargetType.swift
@@ -14,6 +14,7 @@ enum UtilPath: String {
     case notification = "notifications"
     case session = "sessions"
     case user = "users"
+    case s3 = "s3"
 }
 
 protocol BaseTargetType: TargetType {

--- a/EKO-iOS/EKO-iOS/Network/Base/NetworkService.swift
+++ b/EKO-iOS/EKO-iOS/Network/Base/NetworkService.swift
@@ -14,7 +14,7 @@ final class NetworkService {
     private init() {}
     
     let feedbackService: FeedbackAPIServiceProtocol = FeedbackAPIService()
-    //let noteService: SessionAPIServiceProtocol = NoteAPIService()
+    let noteService: NoteAPIServiceProtocol = NoteAPIService()
     //let notificationService: SessionAPIServiceProtocol = NotificationAPIService()
     let sessionService: SessionAPIServiceProtocol = SessionAPIService()
     //let userService: SessionAPIServiceProtocol = UserAPIService()

--- a/EKO-iOS/EKO-iOS/Network/Base/NetworkService.swift
+++ b/EKO-iOS/EKO-iOS/Network/Base/NetworkService.swift
@@ -13,9 +13,10 @@ final class NetworkService {
 
     private init() {}
     
-    //let feedbackService: FeedbackAPIServiceProtocol = FeedbackAPIService()
+    let feedbackService: FeedbackAPIServiceProtocol = FeedbackAPIService()
     //let noteService: SessionAPIServiceProtocol = NoteAPIService()
     //let notificationService: SessionAPIServiceProtocol = NotificationAPIService()
     let sessionService: SessionAPIServiceProtocol = SessionAPIService()
     //let userService: SessionAPIServiceProtocol = UserAPIService()
+    let s3Service: S3APIServiceProtocol = S3APIService()
 }

--- a/EKO-iOS/EKO-iOS/Network/Base/NetworkService.swift
+++ b/EKO-iOS/EKO-iOS/Network/Base/NetworkService.swift
@@ -15,7 +15,7 @@ final class NetworkService {
     
     let feedbackService: FeedbackAPIServiceProtocol = FeedbackAPIService()
     let noteService: NoteAPIServiceProtocol = NoteAPIService()
-    //let notificationService: SessionAPIServiceProtocol = NotificationAPIService()
+    let notificationService: NotificationAPIServiceProtocol = NotificationAPIService()
     let sessionService: SessionAPIServiceProtocol = SessionAPIService()
     //let userService: SessionAPIServiceProtocol = UserAPIService()
     let s3Service: S3APIServiceProtocol = S3APIService()

--- a/EKO-iOS/EKO-iOS/Network/Feedback/FeedbackAPIService.swift
+++ b/EKO-iOS/EKO-iOS/Network/Feedback/FeedbackAPIService.swift
@@ -6,3 +6,45 @@
 //
 
 import Foundation
+import Moya
+
+protocol FeedbackAPIServiceProtocol {
+    func fetchSendFeedback(receiverUserId: String) async throws ->
+        [FetchSendFeedbackResponseDTO]
+    func postStartFeedback(model: PostStartFeedbackRequsetDTO) async throws -> [PostStartFeedbackResponseDTO]
+}
+
+final class FeedbackAPIService: BaseAPIService<FeedbackTargetType>, FeedbackAPIServiceProtocol {
+    
+    private let provider = MoyaProvider<FeedbackTargetType>(plugins: [MoyaLoggerPlugin()])
+    
+    func fetchSendFeedback(receiverUserId: String) async throws -> [FetchSendFeedbackResponseDTO] {
+        let response = try await provider.request(.fetchSendFeedback(receiverUserId: receiverUserId))
+        let result: NetworkResult<[FetchSendFeedbackResponseDTO]> = fetchNetworkResult(
+            statusCode: response.statusCode,
+            data: response.data
+        )
+        switch result {
+        case .success(let data):
+            guard let data else { throw NetworkResult<Error>.decodeErr }
+            return data
+        default:
+            throw NetworkResult<Error>.networkFail
+        }
+    }
+    
+    func postStartFeedback(model: PostStartFeedbackRequsetDTO) async throws -> [PostStartFeedbackResponseDTO] {
+        let response = try await provider.request(.postStartFeedback(model: model))
+        let result: NetworkResult<[PostStartFeedbackResponseDTO]> = fetchNetworkResult(
+            statusCode: response.statusCode,
+            data: response.data
+        )
+        switch result {
+        case .success(let data):
+            guard let data else { throw NetworkResult<Error>.decodeErr }
+            return data
+        default:
+            throw NetworkResult<Error>.networkFail
+        }
+    }
+}

--- a/EKO-iOS/EKO-iOS/Network/Feedback/FeedbackTargetType.swift
+++ b/EKO-iOS/EKO-iOS/Network/Feedback/FeedbackTargetType.swift
@@ -28,8 +28,8 @@ extension FeedbackTargetType: BaseTargetType {
     
     var queryParameter: [String: Any]? {
         switch self {
-        case .fetchSendFeedback(let senderUserId):
-            return ["receiverUserId": senderUserId]
+        case .fetchSendFeedback(let receiverUserId):
+            return ["receiverUserId": receiverUserId]
         default:
             return .none
         }

--- a/EKO-iOS/EKO-iOS/Network/Feedback/FeedbackTargetType.swift
+++ b/EKO-iOS/EKO-iOS/Network/Feedback/FeedbackTargetType.swift
@@ -60,7 +60,7 @@ extension FeedbackTargetType: BaseTargetType {
         switch self {
         case let .fetchSendFeedback(receiverUserId):
             return .requestParameters(parameters: ["receiverUserId": receiverUserId],
-                                      encoding: JSONEncoding.default)
+                                      encoding: URLEncoding.default)
         case let .postStartFeedback(model):
             var multipart: [MultipartFormData] = []
             

--- a/EKO-iOS/EKO-iOS/Network/Feedback/FeedbackTargetType.swift
+++ b/EKO-iOS/EKO-iOS/Network/Feedback/FeedbackTargetType.swift
@@ -59,8 +59,7 @@ extension FeedbackTargetType: BaseTargetType {
     var task: Task {
         switch self {
         case let .fetchSendFeedback(receiverUserId):
-            return .requestParameters(parameters: ["receiverUserId": receiverUserId],
-                                      encoding: URLEncoding.default)
+            return .requestParameters(parameters: ["receiverUserId": receiverUserId], encoding: URLEncoding.default)
         case let .postStartFeedback(model):
             var multipart: [MultipartFormData] = []
             

--- a/EKO-iOS/EKO-iOS/Network/Feedback/FeedbackTargetType.swift
+++ b/EKO-iOS/EKO-iOS/Network/Feedback/FeedbackTargetType.swift
@@ -92,14 +92,14 @@ extension FeedbackTargetType: BaseTargetType {
                 )
             )
             
-            multipart.append(
-                MultipartFormData(
-                    provider: .file(model.feedbackFileURL),
+            if model.status == "Bad", let fileURL = model.feedbackFileURL {
+                multipart.append(MultipartFormData(
+                    provider: .file(fileURL),
                     name: "feedbackFile",
-                    fileName: model.feedbackFileURL.lastPathComponent,
+                    fileName: fileURL.lastPathComponent,
                     mimeType: "audio/m4a"
-                )
-            )
+                ))
+            }
             
             return .uploadMultipart(multipart)
         }

--- a/EKO-iOS/EKO-iOS/Network/Note/NoteAPIService.swift
+++ b/EKO-iOS/EKO-iOS/Network/Note/NoteAPIService.swift
@@ -12,6 +12,7 @@ protocol NoteAPIServiceProtocol {
     func fetchFeedbackNotes(senderId: String) async throws -> [FetchFeedbackNotesResponseDTO]
     func patchFeedbackNoteFavorite(model: PatchNoteFavoriteRequestDTO) async throws -> [PatchFeedbackNoteFavoriteResponseDTO]
     func patchFeedbackNoteTitle(model: PatchNoteTitleRequestDTO) async throws -> [PatchFeedbackNoteTitleResponseDTO]
+    func deleteFeedbackNote(model: DeleteFeedbackNoteRequestDTO) async throws -> [DeleteFeedbackNoteResponseDTO]
 }
 
 final class NoteAPIService: BaseAPIService<NoteTargetType>, NoteAPIServiceProtocol {
@@ -54,6 +55,23 @@ final class NoteAPIService: BaseAPIService<NoteTargetType>, NoteAPIServiceProtoc
         let response = try await provider.request(.patchFeedbackNoteTitle(model: model))
             
         let result: NetworkResult<[PatchFeedbackNoteTitleResponseDTO]> = fetchNetworkResult(
+            statusCode: response.statusCode,
+            data: response.data
+        )
+        
+        switch result {
+        case .success(let data):
+            guard let data else { throw NetworkResult<Error>.decodeErr }
+            return data
+        default:
+            throw NetworkResult<Error>.networkFail
+        }
+    }
+    
+    func deleteFeedbackNote(model: DeleteFeedbackNoteRequestDTO) async throws -> [DeleteFeedbackNoteResponseDTO] {
+        let response = try await provider.request(.deleteFeedbackNote(model: model))
+            
+        let result: NetworkResult<[DeleteFeedbackNoteResponseDTO]> = fetchNetworkResult(
             statusCode: response.statusCode,
             data: response.data
         )

--- a/EKO-iOS/EKO-iOS/Network/Note/NoteAPIService.swift
+++ b/EKO-iOS/EKO-iOS/Network/Note/NoteAPIService.swift
@@ -6,3 +6,28 @@
 //
 
 import Foundation
+import Moya
+
+protocol NoteAPIServiceProtocol {
+    func fetchFeedbackNotes(senderId: String) async throws -> [FetchFeedbackNotesResponseDTO]
+}
+
+final class NoteAPIService: BaseAPIService<NoteTargetType>, NoteAPIServiceProtocol {
+    
+    private let provider = MoyaProvider<NoteTargetType>(plugins: [MoyaLoggerPlugin()])
+    
+    func fetchFeedbackNotes(senderId: String) async throws -> [FetchFeedbackNotesResponseDTO] {
+        let response = try await provider.request(.fetchFeedbackNotes(senderId: senderId))
+        let result: NetworkResult<[FetchFeedbackNotesResponseDTO]> = fetchNetworkResult(
+            statusCode: response.statusCode,
+            data: response.data
+        )
+        switch result {
+        case .success(let data):
+            guard let data else { throw NetworkResult<Error>.decodeErr }
+            return data
+        default:
+            throw NetworkResult<Error>.networkFail
+        }
+    }
+}

--- a/EKO-iOS/EKO-iOS/Network/Note/NoteAPIService.swift
+++ b/EKO-iOS/EKO-iOS/Network/Note/NoteAPIService.swift
@@ -10,6 +10,7 @@ import Moya
 
 protocol NoteAPIServiceProtocol {
     func fetchFeedbackNotes(senderId: String) async throws -> [FetchFeedbackNotesResponseDTO]
+    func patchFeedbackNoteFavorite(model: PatchNoteFavoriteRequestDTO) async throws -> [PatchFeedbackNoteFavoriteResponseDTO]
 }
 
 final class NoteAPIService: BaseAPIService<NoteTargetType>, NoteAPIServiceProtocol {
@@ -22,6 +23,23 @@ final class NoteAPIService: BaseAPIService<NoteTargetType>, NoteAPIServiceProtoc
             statusCode: response.statusCode,
             data: response.data
         )
+        switch result {
+        case .success(let data):
+            guard let data else { throw NetworkResult<Error>.decodeErr }
+            return data
+        default:
+            throw NetworkResult<Error>.networkFail
+        }
+    }
+    
+    func patchFeedbackNoteFavorite(model: PatchNoteFavoriteRequestDTO) async throws -> [PatchFeedbackNoteFavoriteResponseDTO] {
+        let response = try await provider.request(.patchFeedbackNoteFavorite(model: model))
+            
+        let result: NetworkResult<[PatchFeedbackNoteFavoriteResponseDTO]> = fetchNetworkResult(
+            statusCode: response.statusCode,
+            data: response.data
+        )
+        
         switch result {
         case .success(let data):
             guard let data else { throw NetworkResult<Error>.decodeErr }

--- a/EKO-iOS/EKO-iOS/Network/Note/NoteAPIService.swift
+++ b/EKO-iOS/EKO-iOS/Network/Note/NoteAPIService.swift
@@ -11,6 +11,7 @@ import Moya
 protocol NoteAPIServiceProtocol {
     func fetchFeedbackNotes(senderId: String) async throws -> [FetchFeedbackNotesResponseDTO]
     func patchFeedbackNoteFavorite(model: PatchNoteFavoriteRequestDTO) async throws -> [PatchFeedbackNoteFavoriteResponseDTO]
+    func patchFeedbackNoteTitle(model: PatchNoteTitleRequestDTO) async throws -> [PatchFeedbackNoteTitleResponseDTO]
 }
 
 final class NoteAPIService: BaseAPIService<NoteTargetType>, NoteAPIServiceProtocol {
@@ -36,6 +37,23 @@ final class NoteAPIService: BaseAPIService<NoteTargetType>, NoteAPIServiceProtoc
         let response = try await provider.request(.patchFeedbackNoteFavorite(model: model))
             
         let result: NetworkResult<[PatchFeedbackNoteFavoriteResponseDTO]> = fetchNetworkResult(
+            statusCode: response.statusCode,
+            data: response.data
+        )
+        
+        switch result {
+        case .success(let data):
+            guard let data else { throw NetworkResult<Error>.decodeErr }
+            return data
+        default:
+            throw NetworkResult<Error>.networkFail
+        }
+    }
+    
+    func patchFeedbackNoteTitle(model: PatchNoteTitleRequestDTO) async throws -> [PatchFeedbackNoteTitleResponseDTO] {
+        let response = try await provider.request(.patchFeedbackNoteTitle(model: model))
+            
+        let result: NetworkResult<[PatchFeedbackNoteTitleResponseDTO]> = fetchNetworkResult(
             statusCode: response.statusCode,
             data: response.data
         )

--- a/EKO-iOS/EKO-iOS/Network/Note/NoteTargetType.swift
+++ b/EKO-iOS/EKO-iOS/Network/Note/NoteTargetType.swift
@@ -12,6 +12,7 @@ enum NoteTargetType {
     case fetchFeedbackNotes(senderId: String)
     case patchFeedbackNoteFavorite(model: PatchNoteFavoriteRequestDTO)
     case patchFeedbackNoteTitle(model: PatchNoteTitleRequestDTO)
+    case deleteFeedbackNote(model: DeleteFeedbackNoteRequestDTO)
 }
 
 extension NoteTargetType: BaseTargetType {
@@ -26,8 +27,9 @@ extension NoteTargetType: BaseTargetType {
             return ["Content-Type": "application/json"]
         case .patchFeedbackNoteTitle:
             return ["Content-Type": "application/json"]
+        case .deleteFeedbackNote:
+            return ["Content-Type": "application/json"]
         }
-  
     }
     
     var queryParameter: [String: Any]? {
@@ -50,6 +52,7 @@ extension NoteTargetType: BaseTargetType {
         case .fetchFeedbackNotes: return utilPath.rawValue
         case .patchFeedbackNoteFavorite: return utilPath.rawValue + "/favorite"
         case .patchFeedbackNoteTitle: return utilPath.rawValue + "/title"
+        case .deleteFeedbackNote: return utilPath.rawValue
         }
     }
     
@@ -58,6 +61,7 @@ extension NoteTargetType: BaseTargetType {
         case .fetchFeedbackNotes: return .get
         case .patchFeedbackNoteFavorite: return .patch
         case .patchFeedbackNoteTitle: return .patch
+        case .deleteFeedbackNote: return .delete
         }
     }
     
@@ -69,6 +73,8 @@ extension NoteTargetType: BaseTargetType {
         case let .patchFeedbackNoteFavorite(model):
             return .requestJSONEncodable(model)
         case let .patchFeedbackNoteTitle(model):
+            return .requestJSONEncodable(model)
+        case let .deleteFeedbackNote(model):
             return .requestJSONEncodable(model)
         }
     }

--- a/EKO-iOS/EKO-iOS/Network/Note/NoteTargetType.swift
+++ b/EKO-iOS/EKO-iOS/Network/Note/NoteTargetType.swift
@@ -10,6 +10,7 @@ import Moya
 
 enum NoteTargetType {
     case fetchFeedbackNotes(senderId: String)
+    case patchFeedbackNoteFavorite(model: PatchNoteFavoriteRequestDTO)
 }
 
 extension NoteTargetType: BaseTargetType {
@@ -19,6 +20,8 @@ extension NoteTargetType: BaseTargetType {
     var headerType: [String: String?] {
         switch self {
         case .fetchFeedbackNotes:
+            return ["Content-Type": "application/json"]
+        case .patchFeedbackNoteFavorite:
             return ["Content-Type": "application/json"]
         }
     }
@@ -41,12 +44,14 @@ extension NoteTargetType: BaseTargetType {
     var path: String {
         switch self {
         case .fetchFeedbackNotes: return utilPath.rawValue
+        case .patchFeedbackNoteFavorite: return utilPath.rawValue + "/favorite"
         }
     }
     
     var method: Moya.Method {
         switch self {
         case .fetchFeedbackNotes: return .get
+        case .patchFeedbackNoteFavorite: return .patch
         }
     }
     
@@ -55,6 +60,8 @@ extension NoteTargetType: BaseTargetType {
         case let .fetchFeedbackNotes(senderId):
             return .requestParameters(parameters: ["senderId": senderId],
                                       encoding: URLEncoding.default)
+        case let .patchFeedbackNoteFavorite(model):
+            return .requestJSONEncodable(model)
         }
     }
 }

--- a/EKO-iOS/EKO-iOS/Network/Note/NoteTargetType.swift
+++ b/EKO-iOS/EKO-iOS/Network/Note/NoteTargetType.swift
@@ -11,6 +11,7 @@ import Moya
 enum NoteTargetType {
     case fetchFeedbackNotes(senderId: String)
     case patchFeedbackNoteFavorite(model: PatchNoteFavoriteRequestDTO)
+    case patchFeedbackNoteTitle(model: PatchNoteTitleRequestDTO)
 }
 
 extension NoteTargetType: BaseTargetType {
@@ -23,7 +24,10 @@ extension NoteTargetType: BaseTargetType {
             return ["Content-Type": "application/json"]
         case .patchFeedbackNoteFavorite:
             return ["Content-Type": "application/json"]
+        case .patchFeedbackNoteTitle:
+            return ["Content-Type": "application/json"]
         }
+  
     }
     
     var queryParameter: [String: Any]? {
@@ -45,6 +49,7 @@ extension NoteTargetType: BaseTargetType {
         switch self {
         case .fetchFeedbackNotes: return utilPath.rawValue
         case .patchFeedbackNoteFavorite: return utilPath.rawValue + "/favorite"
+        case .patchFeedbackNoteTitle: return utilPath.rawValue + "/title"
         }
     }
     
@@ -52,6 +57,7 @@ extension NoteTargetType: BaseTargetType {
         switch self {
         case .fetchFeedbackNotes: return .get
         case .patchFeedbackNoteFavorite: return .patch
+        case .patchFeedbackNoteTitle: return .patch
         }
     }
     
@@ -61,6 +67,8 @@ extension NoteTargetType: BaseTargetType {
             return .requestParameters(parameters: ["senderId": senderId],
                                       encoding: URLEncoding.default)
         case let .patchFeedbackNoteFavorite(model):
+            return .requestJSONEncodable(model)
+        case let .patchFeedbackNoteTitle(model):
             return .requestJSONEncodable(model)
         }
     }

--- a/EKO-iOS/EKO-iOS/Network/Note/NoteTargetType.swift
+++ b/EKO-iOS/EKO-iOS/Network/Note/NoteTargetType.swift
@@ -6,3 +6,55 @@
 //
 
 import Foundation
+import Moya
+
+enum NoteTargetType {
+    case fetchFeedbackNotes(senderId: String)
+}
+
+extension NoteTargetType: BaseTargetType {
+    var utilPath: UtilPath { return .note }
+    var pathParameter: String? { return .none }
+    
+    var headerType: [String: String?] {
+        switch self {
+        case .fetchFeedbackNotes:
+            return ["Content-Type": "application/json"]
+        }
+    }
+    
+    var queryParameter: [String: Any]? {
+        switch self {
+        case .fetchFeedbackNotes(let senderId):
+            return ["senderId": senderId]
+        default: return .none
+        }
+    }
+    
+    var requestBodyParameter: (any Codable)? {
+        switch self {
+        case .fetchFeedbackNotes: return .none
+        default: return .none
+        }
+    }
+    
+    var path: String {
+        switch self {
+        case .fetchFeedbackNotes: return utilPath.rawValue
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .fetchFeedbackNotes: return .get
+        }
+    }
+    
+    var task: Task {
+        switch self {
+        case let .fetchFeedbackNotes(senderId):
+            return .requestParameters(parameters: ["senderId": senderId],
+                                      encoding: URLEncoding.default)
+        }
+    }
+}

--- a/EKO-iOS/EKO-iOS/Network/Notification/NotificationAPIService.swift
+++ b/EKO-iOS/EKO-iOS/Network/Notification/NotificationAPIService.swift
@@ -6,3 +6,28 @@
 //
 
 import Foundation
+import Moya
+
+protocol NotificationAPIServiceProtocol {
+    func postDeviceToken(model: PostDeviceTokenRequestDTO) async throws -> [PostDeviceTokenResponseDTO]
+}
+
+final class NotificationAPIService: BaseAPIService<SessionTargetType>, NotificationAPIServiceProtocol {
+    
+    private let provider = MoyaProvider<NotificationTargetType>(plugins: [MoyaLoggerPlugin()])
+    
+    func postDeviceToken(model: PostDeviceTokenRequestDTO) async throws -> [PostDeviceTokenResponseDTO] {
+        let response = try await provider.request(.postDeviceToken(model: model))
+        let result: NetworkResult<[PostDeviceTokenResponseDTO]> = fetchNetworkResult(
+            statusCode: response.statusCode,
+            data: response.data
+        )
+        switch result {
+        case .success(let data):
+            guard let data else { throw NetworkResult<Error>.decodeErr }
+            return data
+        default:
+            throw NetworkResult<Error>.networkFail
+        }
+    }
+}

--- a/EKO-iOS/EKO-iOS/Network/Notification/NotificationTargetType.swift
+++ b/EKO-iOS/EKO-iOS/Network/Notification/NotificationTargetType.swift
@@ -6,3 +6,41 @@
 //
 
 import Foundation
+import Moya
+
+enum NotificationTargetType {
+    case postDeviceToken(model: PostDeviceTokenRequestDTO)
+}
+
+extension NotificationTargetType: BaseTargetType {
+    var utilPath: UtilPath { return .notification }
+    var pathParameter: String? { return .none }
+    var queryParameter: [String: Any]? { return .none }
+    var requestBodyParameter: Codable? { return .none }
+    
+    var headerType: [String: String?] {
+        switch self {
+        case .postDeviceToken:
+            return ["Content-Type": "application/json"]
+        }
+    }
+    
+    var path: String {
+        switch self {
+        case .postDeviceToken: return utilPath.rawValue
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .postDeviceToken: return .post
+        }
+    }
+    
+    var task: Task {
+        switch self {
+        case let .postDeviceToken(model):
+            return .requestJSONEncodable(model)
+        }
+    }
+}

--- a/EKO-iOS/EKO-iOS/Network/S3/S3APIService.swift
+++ b/EKO-iOS/EKO-iOS/Network/S3/S3APIService.swift
@@ -1,0 +1,8 @@
+//
+//  UserAPIService.swift
+//  EKO-iOS
+//
+//  Created by mini on 5/29/25.
+//
+
+import Foundation

--- a/EKO-iOS/EKO-iOS/Network/S3/S3APIService.swift
+++ b/EKO-iOS/EKO-iOS/Network/S3/S3APIService.swift
@@ -6,3 +6,28 @@
 //
 
 import Foundation
+import Moya
+
+protocol S3APIServiceProtocol{
+    func fetchS3DownloadURL(s3Key: String) async throws -> [FetchS3DownloadURLResposeDTO]
+}
+
+final class S3APIService: BaseAPIService<S3TargetType>,
+  S3APIServiceProtocol {
+    
+    private let provider = MoyaProvider<S3TargetType>(plugins: [MoyaLoggerPlugin()])
+    
+    func fetchS3DownloadURL(s3Key: String) async throws -> [FetchS3DownloadURLResposeDTO] {
+        let response = try await provider.request(.fetchS3DownloadURL(s3Key: s3Key))
+        let result: NetworkResult<[FetchS3DownloadURLResposeDTO]> = fetchNetworkResult(
+            statusCode: response.statusCode,
+            data: response.data)
+        switch result {
+        case .success(let data):
+            guard let data else { throw NetworkResult<Error>.decodeErr }
+            return data
+        default:
+            throw NetworkResult<Error>.networkFail
+        }
+    }
+}

--- a/EKO-iOS/EKO-iOS/Network/S3/S3APIService.swift
+++ b/EKO-iOS/EKO-iOS/Network/S3/S3APIService.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Moya
 
-protocol S3APIServiceProtocol{
+protocol S3APIServiceProtocol {
     func fetchS3DownloadURL(s3Key: String) async throws -> [FetchS3DownloadURLResposeDTO]
 }
 

--- a/EKO-iOS/EKO-iOS/Network/S3/S3TargetType.swift
+++ b/EKO-iOS/EKO-iOS/Network/S3/S3TargetType.swift
@@ -6,3 +6,53 @@
 //
 
 import Foundation
+import Moya
+
+enum S3TargetType{
+    case fetchS3DownloadURL(s3Key: String)
+}
+
+extension S3TargetType: BaseTargetType {
+    var utilPath: UtilPath { return .s3 }
+    var pathParameter: String? { return .none }
+    
+    var headerType: [String: String?]{
+        switch self {
+        case .fetchS3DownloadURL:
+            return ["Content-Type": "application/json"]
+        }
+    }
+    
+    var queryParameter: [String : Any]? {
+        switch self {
+        case .fetchS3DownloadURL(let s3Key):
+            return ["s3Key": s3Key]
+        }
+    }
+    
+    var requestBodyParameter: Codable? {
+        switch self {
+        case .fetchS3DownloadURL: return .none
+        }
+    }
+    
+    var path: String {
+        switch self {
+        case .fetchS3DownloadURL: return utilPath.rawValue + "presign"
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .fetchS3DownloadURL: return .get
+        }
+    }
+    
+    var task: Task {
+        switch self {
+        case let .fetchS3DownloadURL(s3Key):
+            return .requestParameters(parameters: ["s3Key": s3Key],
+                                      encoding: JSONEncoding.default)
+        }
+    }
+}

--- a/EKO-iOS/EKO-iOS/Network/S3/S3TargetType.swift
+++ b/EKO-iOS/EKO-iOS/Network/S3/S3TargetType.swift
@@ -1,0 +1,8 @@
+//
+//  UserTargetType.swift
+//  EKO-iOS
+//
+//  Created by mini on 5/29/25.
+//
+
+import Foundation

--- a/EKO-iOS/EKO-iOS/Network/S3/S3TargetType.swift
+++ b/EKO-iOS/EKO-iOS/Network/S3/S3TargetType.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Moya
 
-enum S3TargetType{
+enum S3TargetType {
     case fetchS3DownloadURL(s3Key: String)
 }
 
@@ -16,14 +16,14 @@ extension S3TargetType: BaseTargetType {
     var utilPath: UtilPath { return .s3 }
     var pathParameter: String? { return .none }
     
-    var headerType: [String: String?]{
+    var headerType: [String: String?] {
         switch self {
         case .fetchS3DownloadURL:
             return ["Content-Type": "application/json"]
         }
     }
     
-    var queryParameter: [String : Any]? {
+    var queryParameter: [String: Any]? {
         switch self {
         case .fetchS3DownloadURL(let s3Key):
             return ["s3Key": s3Key]
@@ -38,7 +38,7 @@ extension S3TargetType: BaseTargetType {
     
     var path: String {
         switch self {
-        case .fetchS3DownloadURL: return utilPath.rawValue + "presign"
+        case .fetchS3DownloadURL: return utilPath.rawValue + "/presign"
         }
     }
     
@@ -52,7 +52,7 @@ extension S3TargetType: BaseTargetType {
         switch self {
         case let .fetchS3DownloadURL(s3Key):
             return .requestParameters(parameters: ["s3Key": s3Key],
-                                      encoding: JSONEncoding.default)
+                                      encoding: URLEncoding.default)
         }
     }
 }

--- a/EKO-iOS/FetchFeedbackNotesResponseDTO.swift
+++ b/EKO-iOS/FetchFeedbackNotesResponseDTO.swift
@@ -1,0 +1,25 @@
+//
+//  FetchFeedbackNotesResponseDTO.swift
+//  EKO-iOS
+//
+//  Created by 성현 on 5/31/25.
+//
+
+import Foundation
+
+struct FetchFeedbackNotesResponseDTO: Decodable {
+    let notes: [Note]
+}
+
+struct Note: Codable {
+    let sessionId: String
+    let receiverID: String
+    let senderID: String
+    let feedbackTimestamp: Int
+    let status: String
+    let feedbackS3Key: String?
+    let createdAt: Int
+    let isFavorite: Bool
+    let s3Key: String
+    let title: String
+}

--- a/EKO-iOS/FetchS3DownloadURLResposeDTO.swift
+++ b/EKO-iOS/FetchS3DownloadURLResposeDTO.swift
@@ -1,0 +1,8 @@
+//
+//  FetchS3DownloadURLResposeDTO.swift
+//  EKO-iOS
+//
+//  Created by 성현 on 5/31/25.
+//
+
+import Foundation

--- a/EKO-iOS/FetchS3DownloadURLResposeDTO.swift
+++ b/EKO-iOS/FetchS3DownloadURLResposeDTO.swift
@@ -6,3 +6,7 @@
 //
 
 import Foundation
+
+struct FetchS3DownloadURLResposeDTO: Decodable {
+    let url: String
+}

--- a/EKO-iOS/FetchSendFeedbackResponseDTO.swift
+++ b/EKO-iOS/FetchSendFeedbackResponseDTO.swift
@@ -1,0 +1,12 @@
+//
+//  fetchSendFeedback.swift
+//  EKO-iOS
+//
+//  Created by 성현 on 5/31/25.
+//
+
+import Foundation
+
+struct FetchSendFeedbackResponseDTO: Decodable {
+    let sessions: [Session]
+}

--- a/EKO-iOS/PatchFeedbackNoteFavoriteResponseDTO.swift
+++ b/EKO-iOS/PatchFeedbackNoteFavoriteResponseDTO.swift
@@ -1,0 +1,14 @@
+//
+//  PatchFeedbackNoteFavoriteResponseDTO.swift
+//  EKO-iOS
+//
+//  Created by 성현 on 5/31/25.
+//
+
+import Foundation
+
+struct PatchFeedbackNoteFavoriteResponseDTO: Decodable {
+    let message: String
+    let sessionId: String
+    let isFavorite: Bool
+}

--- a/EKO-iOS/PatchFeedbackNoteTitleResponseDTO.swift
+++ b/EKO-iOS/PatchFeedbackNoteTitleResponseDTO.swift
@@ -1,0 +1,14 @@
+//
+//  PatchFeedbackNoteTitleResponseDTO.swift
+//  EKO-iOS
+//
+//  Created by 성현 on 5/31/25.
+//
+
+import Foundation
+
+struct PatchFeedbackNoteTitleResponseDTO: Decodable {
+    let message: String
+    let sessionId: String
+    let title: String
+}

--- a/EKO-iOS/PatchNoteFavoriteRequestDTO.swift
+++ b/EKO-iOS/PatchNoteFavoriteRequestDTO.swift
@@ -1,0 +1,13 @@
+//
+//  PatchNoteFavoriteRequestDTO.swift
+//  EKO-iOS
+//
+//  Created by 성현 on 5/31/25.
+//
+
+import Foundation
+
+struct PatchNoteFavoriteRequestDTO: Encodable {
+    let sessionId: String
+    let isFavorite: Bool
+}

--- a/EKO-iOS/PatchNoteTitleRequestDTO.swift
+++ b/EKO-iOS/PatchNoteTitleRequestDTO.swift
@@ -1,0 +1,13 @@
+//
+//  PatchNoteTitleRequestDTO.swift
+//  EKO-iOS
+//
+//  Created by 성현 on 5/31/25.
+//
+
+import Foundation
+
+struct PatchNoteTitleRequestDTO: Encodable {
+    let sessionId: String
+    let title: String
+}

--- a/EKO-iOS/PostDeviceTokenRequestDTO.swift
+++ b/EKO-iOS/PostDeviceTokenRequestDTO.swift
@@ -1,0 +1,13 @@
+//
+//  PostDeviceTokenRequestDTO.swift
+//  EKO-iOS
+//
+//  Created by 성현 on 5/31/25.
+//
+
+import Foundation
+
+struct PostDeviceTokenRequestDTO: Encodable {
+    let deviceToken: String
+    let userId: String
+}

--- a/EKO-iOS/PostDeviceTokenResponseDTO.swift
+++ b/EKO-iOS/PostDeviceTokenResponseDTO.swift
@@ -1,0 +1,12 @@
+//
+//  PostDeviceTokenResponseDTO.swift
+//  EKO-iOS
+//
+//  Created by 성현 on 5/31/25.
+//
+
+import Foundation
+
+struct PostDeviceTokenResponseDTO: Decodable {
+    let endpointArn: String
+}

--- a/EKO-iOS/PostStartFeedbackRequsetDTO.swift
+++ b/EKO-iOS/PostStartFeedbackRequsetDTO.swift
@@ -12,5 +12,5 @@ struct PostStartFeedbackRequsetDTO: Encodable {
     let receiverUserId: String
     let sessionId: String
     let status: String
-    let feedbackFileURL: URL
+    let feedbackFileURL: URL?
 }

--- a/EKO-iOS/PostStartFeedbackRequsetDTO.swift
+++ b/EKO-iOS/PostStartFeedbackRequsetDTO.swift
@@ -1,0 +1,16 @@
+//
+//  PostSendFeedbackDto.swift
+//  EKO-iOS
+//
+//  Created by 성현 on 5/31/25.
+//
+
+import Foundation
+
+struct PostStartFeedbackRequsetDTO: Encodable {
+    let senderUserId: String
+    let receiverUserId: String
+    let sessionId: String
+    let status: String
+    let feedbackFileURL: URL
+}

--- a/EKO-iOS/PostStartFeedbackResponseDTO.swift
+++ b/EKO-iOS/PostStartFeedbackResponseDTO.swift
@@ -1,0 +1,13 @@
+//
+//  PostStartFeedbackResponseDTO.swift
+//  EKO-iOS
+//
+//  Created by 성현 on 5/31/25.
+//
+
+import Foundation
+
+struct PostStartFeedbackResponseDTO: Decodable {
+    let success: Bool
+    let sessionId: String
+}


### PR DESCRIPTION
## ✨ 해결한 이슈
- Resolved: #17

## 🔍 PR Content
피드백 노트 관리를 위한 네트워크 로직을 Moya 기반으로 구현했습니다.

내용에는 다음 항목이 포함됩니다.
- 노트 조회
- 노트 즐겨찾기 설정
- 노트 타이틀 변경
- 수신받은 피드백 조회
- 전송한 피드백 조회
- 피드백 전송_Good
- 피드백 전송_Bad
- 다운로드 링크 생성
- 디바이스 토큰 등록 (푸시알림용)

또한 번들 식별자 관련 이슈도 함께 수정했습니다.

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인