### PR TITLE
[Feat] #19 디바이스 푸시 알림 구현

### DIFF
--- a/EKO-iOS/EKO-iOS.xcodeproj/project.pbxproj
+++ b/EKO-iOS/EKO-iOS.xcodeproj/project.pbxproj
@@ -7,6 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		099AD8662DEBD24500CC9717 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 099AD8652DEBD23E00CC9717 /* AppDelegate.swift */; };
+		099AD86F2DEBEEDC00CC9717 /* RegisterSubViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 099AD86A2DEBEEDC00CC9717 /* RegisterSubViews.swift */; };
+		099AD8702DEBEEDC00CC9717 /* RegisterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 099AD8672DEBEEDC00CC9717 /* RegisterView.swift */; };
+		099AD8712DEBEEDC00CC9717 /* RegisterModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 099AD8682DEBEEDC00CC9717 /* RegisterModel.swift */; };
+		099AD8722DEBEEDC00CC9717 /* RegisterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 099AD86C2DEBEEDC00CC9717 /* RegisterViewModel.swift */; };
 		09F425162DEBC2B500850CDB /* PostStartFeedbackRequsetDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F425152DEBC2B500850CDB /* PostStartFeedbackRequsetDTO.swift */; };
 		09F425192DEBC2BA00850CDB /* FetchSendFeedbackResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F425172DEBC2BA00850CDB /* FetchSendFeedbackResponseDTO.swift */; };
 		09F4251A2DEBC2BA00850CDB /* PostStartFeedbackResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F425182DEBC2BA00850CDB /* PostStartFeedbackResponseDTO.swift */; };
@@ -86,6 +91,11 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		099AD8652DEBD23E00CC9717 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		099AD8672DEBEEDC00CC9717 /* RegisterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterView.swift; sourceTree = "<group>"; };
+		099AD8682DEBEEDC00CC9717 /* RegisterModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterModel.swift; sourceTree = "<group>"; };
+		099AD86A2DEBEEDC00CC9717 /* RegisterSubViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterSubViews.swift; sourceTree = "<group>"; };
+		099AD86C2DEBEEDC00CC9717 /* RegisterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterViewModel.swift; sourceTree = "<group>"; };
 		09F425152DEBC2B500850CDB /* PostStartFeedbackRequsetDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostStartFeedbackRequsetDTO.swift; sourceTree = "<group>"; };
 		09F425172DEBC2BA00850CDB /* FetchSendFeedbackResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchSendFeedbackResponseDTO.swift; sourceTree = "<group>"; };
 		09F425182DEBC2BA00850CDB /* PostStartFeedbackResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostStartFeedbackResponseDTO.swift; sourceTree = "<group>"; };
@@ -187,6 +197,41 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		099AD8692DEBEEDC00CC9717 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				099AD8682DEBEEDC00CC9717 /* RegisterModel.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		099AD86B2DEBEEDC00CC9717 /* SubViews */ = {
+			isa = PBXGroup;
+			children = (
+				099AD86A2DEBEEDC00CC9717 /* RegisterSubViews.swift */,
+			);
+			path = SubViews;
+			sourceTree = "<group>";
+		};
+		099AD86D2DEBEEDC00CC9717 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				099AD86C2DEBEEDC00CC9717 /* RegisterViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		099AD86E2DEBEEDC00CC9717 /* Register */ = {
+			isa = PBXGroup;
+			children = (
+				099AD8672DEBEEDC00CC9717 /* RegisterView.swift */,
+				099AD8692DEBEEDC00CC9717 /* Model */,
+				099AD86B2DEBEEDC00CC9717 /* SubViews */,
+				099AD86D2DEBEEDC00CC9717 /* ViewModel */,
+			);
+			path = Register;
+			sourceTree = "<group>";
+		};
 		09F4252D2DEBC34D00850CDB /* Request */ = {
 			isa = PBXGroup;
 			children = (
@@ -262,6 +307,7 @@
 		3D2C9E2D2DE5E155009DAE77 /* Application */ = {
 			isa = PBXGroup;
 			children = (
+				099AD8652DEBD23E00CC9717 /* AppDelegate.swift */,
 				3D2C9E272DE5E0A0009DAE77 /* EKO_iOSApp.swift */,
 				3D2C9F082DE60F58009DAE77 /* Coordinator */,
 			);
@@ -277,6 +323,7 @@
 				3D2C9EC72DE5F5A6009DAE77 /* RecordingResponse */,
 				3D2C9EC82DE5F5B7009DAE77 /* LearningNote */,
 				3D2C9EC92DE5F608009DAE77 /* Profile */,
+				099AD86E2DEBEEDC00CC9717 /* Register */,
 				3D2C9ECA2DE5F62F009DAE77 /* AddFriend */,
 			);
 			path = Feature;
@@ -867,6 +914,7 @@
 				09F4251E2DEBC2C400850CDB /* PatchNoteTitleRequestDTO.swift in Sources */,
 				09F4251F2DEBC2C400850CDB /* DeleteFeedbackNoteRequestDTO.swift in Sources */,
 				09F425202DEBC2C400850CDB /* PatchNoteFavoriteRequestDTO.swift in Sources */,
+				099AD8712DEBEEDC00CC9717 /* RegisterModel.swift in Sources */,
 				09F4251A2DEBC2BA00850CDB /* PostStartFeedbackResponseDTO.swift in Sources */,
 				3D2C9ED42DE5F6A6009DAE77 /* AddFriendView.swift in Sources */,
 				3DF3255E2DE7FDD400F9F3F9 /* BaseTargetType.swift in Sources */,
@@ -881,6 +929,7 @@
 				3D2C9EF62DE5FA13009DAE77 /* LearningNoteSubViews.swift in Sources */,
 				3DF327372DE9A9EE00F9F3F9 /* NotificationAPIService.swift in Sources */,
 				3D2C9F0A2DE60F75009DAE77 /* AppRoute.swift in Sources */,
+				099AD8662DEBD24500CC9717 /* AppDelegate.swift in Sources */,
 				3D2C9F042DE5FA85009DAE77 /* AddFriendModel.swift in Sources */,
 				3DF3260F2DE8965600F9F3F9 /* UserAPIService.swift in Sources */,
 				3D2C9F022DE5FA7F009DAE77 /* AddFriendSubViews.swift in Sources */,
@@ -888,8 +937,10 @@
 				3D2C9EEC2DE5F988009DAE77 /* RecordingResponseSubView.swift in Sources */,
 				3DF3260D2DE895B100F9F3F9 /* UserTargetType.swift in Sources */,
 				3D2C9ED02DE5F696009DAE77 /* RecordingResponseView.swift in Sources */,
+				099AD86F2DEBEEDC00CC9717 /* RegisterSubViews.swift in Sources */,
 				3DF327392DE9AA3F00F9F3F9 /* PostStartQuestionRequestDTO.swift in Sources */,
 				3DF327352DE9A9E400F9F3F9 /* NotificationTargetType.swift in Sources */,
+				099AD8702DEBEEDC00CC9717 /* RegisterView.swift in Sources */,
 				3D2C9EEA2DE5F96C009DAE77 /* RecordingResponseModel.swift in Sources */,
 				3DF326192DE9871000F9F3F9 /* FetchSendQuestionResponseDTO.swift in Sources */,
 				3D2C9ECC2DE5F665009DAE77 /* LearningNoteView.swift in Sources */,
@@ -918,6 +969,7 @@
 				3DF3260B2DE895AA00F9F3F9 /* SessionAPIService.swift in Sources */,
 				3D2C9E2C2DE5E0A0009DAE77 /* EKO_iOSApp.swift in Sources */,
 				09F4252A2DEBC2D000850CDB /* PostDeviceTokenRequestDTO.swift in Sources */,
+				099AD8722DEBEEDC00CC9717 /* RegisterViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/EKO-iOS/EKO-iOS/Application/AppDelegate.swift
+++ b/EKO-iOS/EKO-iOS/Application/AppDelegate.swift
@@ -1,0 +1,49 @@
+//
+//  APPDelegate.swift
+//  EKO-iOS
+//
+//  Created by 성현 on 5/29/25.
+//
+
+import UIKit
+import UserNotifications
+
+class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
+    
+    func application(_ application: UIApplication,
+                     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        UNUserNotificationCenter.current().delegate = self
+        requestPushAuthorization()
+        return true
+    }
+
+    func requestPushAuthorization() {
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { granted, _ in
+            if granted {
+                DispatchQueue.main.async {
+                    UIApplication.shared.registerForRemoteNotifications()
+                }
+            } else {
+                print("푸시 권한 거부됨")
+            }
+        }
+    }
+
+    func application(_ application: UIApplication,
+                     didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        let token = deviceToken.map { String(format: "%02x", $0) }.joined()
+        print("디바이스 토큰 수신: \(token)")
+        UserDefaults.standard.set(token, forKey: "deviceToken")
+    }
+
+    func application(_ application: UIApplication,
+                     didFailToRegisterForRemoteNotificationsWithError error: Error) {
+        print("디바이스 푸시 등록 실패: \(error.localizedDescription)")
+    }
+
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                willPresent notification: UNNotification,
+                                withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        completionHandler([.banner, .sound, .badge])
+    }
+}

--- a/EKO-iOS/EKO-iOS/Application/Coordinator/AppRoute.swift
+++ b/EKO-iOS/EKO-iOS/Application/Coordinator/AppRoute.swift
@@ -14,4 +14,5 @@ enum AppRoute: Hashable {
     case learningNote
     case profile
     case addFriend
+    case register
 }

--- a/EKO-iOS/EKO-iOS/Application/Coordinator/RootNavigationView.swift
+++ b/EKO-iOS/EKO-iOS/Application/Coordinator/RootNavigationView.swift
@@ -12,7 +12,13 @@ struct RootNavigationView: View {
     
     var body: some View {
         NavigationStack(path: $coordinator.path) {
-            MainView()
+            Group {
+                if UserDefaults.standard.string(forKey: "userId") != nil {
+                        MainView()
+                    } else {
+                        RegisterView()
+                    }
+            }
             .navigationDestination(for: AppRoute.self) { route in
                 switch route {
                 case .main: MainView()
@@ -21,6 +27,7 @@ struct RootNavigationView: View {
                 case .learningNote: LearningNoteView()
                 case .profile: ProfileView()
                 case .addFriend: AddFriendView()
+                case .register: RegisterView()
                 }
             }
         }

--- a/EKO-iOS/EKO-iOS/Application/EKO_iOSApp.swift
+++ b/EKO-iOS/EKO-iOS/Application/EKO_iOSApp.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 @main
 struct EKO_iOSApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     @StateObject private var coordinator = AppCoordinator()
 
     var body: some Scene {

--- a/EKO-iOS/EKO-iOS/Feature/Register/Model/RegisterModel.swift
+++ b/EKO-iOS/EKO-iOS/Feature/Register/Model/RegisterModel.swift
@@ -1,0 +1,8 @@
+//
+//  ProfileModel.swift
+//  EKO-iOS
+//
+//  Created by mini on 5/27/25.
+//
+
+import Foundation

--- a/EKO-iOS/EKO-iOS/Feature/Register/RegisterView.swift
+++ b/EKO-iOS/EKO-iOS/Feature/Register/RegisterView.swift
@@ -1,0 +1,66 @@
+//
+//  ProfileView.swift
+//  EKO-iOS
+//
+//  Created by mini on 5/27/25.
+//
+
+import SwiftUI
+
+struct RegisterView: View {
+    @EnvironmentObject private var coordinator: AppCoordinator
+    
+    @State private var userId: String = ""
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("임시 회원가입")
+                .font(.title2)
+                .bold()
+
+            TextField("User ID 입력", text: $userId)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .padding(.horizontal)
+
+            Button("가입") {
+                Task {
+                    await registerDeviceTokenIfNeeded(userId: userId)
+                }
+            }
+            .padding()
+            .disabled(userId.isEmpty)
+        }
+        .padding()
+    }
+
+    func registerDeviceTokenIfNeeded(userId: String) async {
+        guard let token = UserDefaults.standard.string(forKey: "deviceToken") else {
+            print("디바이스 토큰이 아직 저장되지 않았습니다")
+            return
+        }
+
+        let dto = PostDeviceTokenRequestDTO(deviceToken: token, userId: userId)
+
+        do {
+            let resultArray = try await NetworkService.shared.notificationService.postDeviceToken(model: dto)
+            guard let first = resultArray.first else {
+                print("❌ 디코딩 성공했지만 응답 배열이 비어있습니다")
+                return
+            }
+
+            print("✅ 등록 성공: \(first.endpointArn)")
+            UserDefaults.standard.set(userId, forKey: "userId")
+
+            await MainActor.run {
+                coordinator.path = NavigationPath()
+                coordinator.path.append(AppRoute.main)
+            }
+        } catch {
+            print("❌ 등록 실패: \(error.localizedDescription)")
+        }
+    }
+}
+
+#Preview {
+    RegisterView()
+}

--- a/EKO-iOS/EKO-iOS/Feature/Register/SubViews/RegisterSubViews.swift
+++ b/EKO-iOS/EKO-iOS/Feature/Register/SubViews/RegisterSubViews.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct ProfileSubViews: View {
+struct RegisterSubViews: View {
     var body: some View {
         Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
     }

--- a/EKO-iOS/EKO-iOS/Feature/Register/ViewModel/RegisterViewModel.swift
+++ b/EKO-iOS/EKO-iOS/Feature/Register/ViewModel/RegisterViewModel.swift
@@ -1,0 +1,8 @@
+//
+//  ProfileViewModel.swift
+//  EKO-iOS
+//
+//  Created by mini on 5/27/25.
+//
+
+import Foundation

--- a/EKO-iOS/EKO-iOS/Network/Note/DTO/Response/DeleteFeedbackNoteResponseDTO.swift
+++ b/EKO-iOS/EKO-iOS/Network/Note/DTO/Response/DeleteFeedbackNoteResponseDTO.swift
@@ -11,4 +11,3 @@ struct DeleteFeedbackNoteResponseDTO: Decodable {
     let message: String
     let sessionId: String
 }
-

--- a/EKO-iOS/EKO-iOS/Network/Notification/NotificationAPIService.swift
+++ b/EKO-iOS/EKO-iOS/Network/Notification/NotificationAPIService.swift
@@ -18,14 +18,16 @@ final class NotificationAPIService: BaseAPIService<SessionTargetType>, Notificat
     
     func postDeviceToken(model: PostDeviceTokenRequestDTO) async throws -> [PostDeviceTokenResponseDTO] {
         let response = try await provider.request(.postDeviceToken(model: model))
-        let result: NetworkResult<[PostDeviceTokenResponseDTO]> = fetchNetworkResult(
+        
+        let result: NetworkResult<PostDeviceTokenResponseDTO> = fetchNetworkResult(
             statusCode: response.statusCode,
             data: response.data
         )
+        
         switch result {
         case .success(let data):
             guard let data else { throw NetworkResult<Error>.decodeErr }
-            return data
+            return [data]
         default:
             throw NetworkResult<Error>.networkFail
         }

--- a/EKO-iOS/EKO-iOS/Network/Notification/NotificationTargetType.swift
+++ b/EKO-iOS/EKO-iOS/Network/Notification/NotificationTargetType.swift
@@ -27,7 +27,7 @@ extension NotificationTargetType: BaseTargetType {
     
     var path: String {
         switch self {
-        case .postDeviceToken: return utilPath.rawValue
+        case .postDeviceToken: return utilPath.rawValue + "/register"
         }
     }
     


### PR DESCRIPTION
## ✨ 해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #19

## 🔍 PR Content
<!-- 작업 내용 설명 -->
- AppDelegate를 사용하여 기기 실행 초기에 알림 권한 설정 요청을 받은 후 디바이스 토큰을 생성한 후 userDefault에 해당값을 저장하고, 백그라운드에서 알림이 수신되게 하였습니다.

- RegisterView를 임시로 구성하여 디바이스토큰을 바탕으로 userId를 연결할 수 있게 만들었습니다. 해당 userId는 userDefault에 저장됩니다. 추후에 Apple로 로그인 기능으로 개선할 예정입니다.

- RootNavigationView를 개선하여 userId 여부에 따라 RegisterView를 호출하도록 설정하였습니다. userId가 있으면 바로 MainView를 호출합니다.



## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->
RegisterView 분기처리 과정에서 AppDelegate에서 분기처리를 하는 것이 메모리 처리에 좀 더 이득일 것 같은 생각이 들었는데, 코드 직관성을 위해서 일단은 RootNavigationView에서 처리했습니다. 차이가 없을까요?

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
