### PR TITLE
[Feat] #24 - 재사용 UI Component 제작

### DIFF
--- a/EKO-iOS/.swiftlint.yml
+++ b/EKO-iOS/.swiftlint.yml
@@ -8,6 +8,7 @@ disabled_rules:
 - function_body_length
 - nesting
 - cyclomatic_complexity
+- shorthand_operator
 # 린트 과정에서 무시할 파일 경로
 excluded:
 - EKO-iOS/Application/EKO_iOSApp.swift

--- a/EKO-iOS/EKO-iOS.xcodeproj/project.pbxproj
+++ b/EKO-iOS/EKO-iOS.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		09F425362DEBC34D00850CDB /* S3APIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F425312DEBC34D00850CDB /* S3APIService.swift */; };
 		3D2796162DED3283005D5A1B /* EKOToastMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D2796152DED3283005D5A1B /* EKOToastMessage.swift */; };
 		3D2796192DED36CC005D5A1B /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D2796182DED36CC005D5A1B /* View+.swift */; };
+		3D27961B2DED9B13005D5A1B /* EKOToggleIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D27961A2DED9B13005D5A1B /* EKOToggleIndicator.swift */; };
 		3D2C9E292DE5E0A0009DAE77 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3D2C9E222DE5E0A0009DAE77 /* Preview Assets.xcassets */; };
 		3D2C9E2A2DE5E0A0009DAE77 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3D2C9E242DE5E0A0009DAE77 /* Assets.xcassets */; };
 		3D2C9E2B2DE5E0A0009DAE77 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D2C9E252DE5E0A0009DAE77 /* ContentView.swift */; };
@@ -115,6 +116,7 @@
 		09F425322DEBC34D00850CDB /* S3TargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = S3TargetType.swift; sourceTree = "<group>"; };
 		3D2796152DED3283005D5A1B /* EKOToastMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EKOToastMessage.swift; sourceTree = "<group>"; };
 		3D2796182DED36CC005D5A1B /* View+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
+		3D27961A2DED9B13005D5A1B /* EKOToggleIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EKOToggleIndicator.swift; sourceTree = "<group>"; };
 		3D2C9E102DE5E031009DAE77 /* EKO-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "EKO-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3D2C9E222DE5E0A0009DAE77 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		3D2C9E242DE5E0A0009DAE77 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -274,6 +276,7 @@
 			isa = PBXGroup;
 			children = (
 				3D2796152DED3283005D5A1B /* EKOToastMessage.swift */,
+				3D27961A2DED9B13005D5A1B /* EKOToggleIndicator.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -930,6 +933,7 @@
 				09F4251F2DEBC2C400850CDB /* DeleteFeedbackNoteRequestDTO.swift in Sources */,
 				09F425202DEBC2C400850CDB /* PatchNoteFavoriteRequestDTO.swift in Sources */,
 				099AD8712DEBEEDC00CC9717 /* RegisterModel.swift in Sources */,
+				3D27961B2DED9B13005D5A1B /* EKOToggleIndicator.swift in Sources */,
 				09F4251A2DEBC2BA00850CDB /* PostStartFeedbackResponseDTO.swift in Sources */,
 				3D2C9ED42DE5F6A6009DAE77 /* AddFriendView.swift in Sources */,
 				3DF3255E2DE7FDD400F9F3F9 /* BaseTargetType.swift in Sources */,

--- a/EKO-iOS/EKO-iOS.xcodeproj/project.pbxproj
+++ b/EKO-iOS/EKO-iOS.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		3D2796162DED3283005D5A1B /* EKOToastMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D2796152DED3283005D5A1B /* EKOToastMessage.swift */; };
 		3D2796192DED36CC005D5A1B /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D2796182DED36CC005D5A1B /* View+.swift */; };
 		3D27961B2DED9B13005D5A1B /* EKOToggleIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D27961A2DED9B13005D5A1B /* EKOToggleIndicator.swift */; };
+		3D27961D2DEDA71B005D5A1B /* EKOButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D27961C2DEDA71B005D5A1B /* EKOButton.swift */; };
 		3D2C9E292DE5E0A0009DAE77 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3D2C9E222DE5E0A0009DAE77 /* Preview Assets.xcassets */; };
 		3D2C9E2A2DE5E0A0009DAE77 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3D2C9E242DE5E0A0009DAE77 /* Assets.xcassets */; };
 		3D2C9E2B2DE5E0A0009DAE77 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D2C9E252DE5E0A0009DAE77 /* ContentView.swift */; };
@@ -117,6 +118,7 @@
 		3D2796152DED3283005D5A1B /* EKOToastMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EKOToastMessage.swift; sourceTree = "<group>"; };
 		3D2796182DED36CC005D5A1B /* View+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
 		3D27961A2DED9B13005D5A1B /* EKOToggleIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EKOToggleIndicator.swift; sourceTree = "<group>"; };
+		3D27961C2DEDA71B005D5A1B /* EKOButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EKOButton.swift; sourceTree = "<group>"; };
 		3D2C9E102DE5E031009DAE77 /* EKO-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "EKO-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3D2C9E222DE5E0A0009DAE77 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		3D2C9E242DE5E0A0009DAE77 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -277,6 +279,7 @@
 			children = (
 				3D2796152DED3283005D5A1B /* EKOToastMessage.swift */,
 				3D27961A2DED9B13005D5A1B /* EKOToggleIndicator.swift */,
+				3D27961C2DEDA71B005D5A1B /* EKOButton.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -954,6 +957,7 @@
 				3D2C9F022DE5FA7F009DAE77 /* AddFriendSubViews.swift in Sources */,
 				3D2C9EE52DE5F926009DAE77 /* RecordingRequestSubView.swift in Sources */,
 				3D2C9EEC2DE5F988009DAE77 /* RecordingResponseSubView.swift in Sources */,
+				3D27961D2DEDA71B005D5A1B /* EKOButton.swift in Sources */,
 				3DF3260D2DE895B100F9F3F9 /* UserTargetType.swift in Sources */,
 				3D2C9ED02DE5F696009DAE77 /* RecordingResponseView.swift in Sources */,
 				3D2796192DED36CC005D5A1B /* View+.swift in Sources */,

--- a/EKO-iOS/EKO-iOS.xcodeproj/project.pbxproj
+++ b/EKO-iOS/EKO-iOS.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		09F425342DEBC34D00850CDB /* S3TargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F425322DEBC34D00850CDB /* S3TargetType.swift */; };
 		09F425352DEBC34D00850CDB /* FetchS3DownloadURLResposeDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F4252E2DEBC34D00850CDB /* FetchS3DownloadURLResposeDTO.swift */; };
 		09F425362DEBC34D00850CDB /* S3APIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F425312DEBC34D00850CDB /* S3APIService.swift */; };
+		3D2796162DED3283005D5A1B /* EKOToastMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D2796152DED3283005D5A1B /* EKOToastMessage.swift */; };
+		3D2796192DED36CC005D5A1B /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D2796182DED36CC005D5A1B /* View+.swift */; };
 		3D2C9E292DE5E0A0009DAE77 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3D2C9E222DE5E0A0009DAE77 /* Preview Assets.xcassets */; };
 		3D2C9E2A2DE5E0A0009DAE77 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3D2C9E242DE5E0A0009DAE77 /* Assets.xcassets */; };
 		3D2C9E2B2DE5E0A0009DAE77 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D2C9E252DE5E0A0009DAE77 /* ContentView.swift */; };
@@ -111,6 +113,8 @@
 		09F4252E2DEBC34D00850CDB /* FetchS3DownloadURLResposeDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchS3DownloadURLResposeDTO.swift; sourceTree = "<group>"; };
 		09F425312DEBC34D00850CDB /* S3APIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = S3APIService.swift; sourceTree = "<group>"; };
 		09F425322DEBC34D00850CDB /* S3TargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = S3TargetType.swift; sourceTree = "<group>"; };
+		3D2796152DED3283005D5A1B /* EKOToastMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EKOToastMessage.swift; sourceTree = "<group>"; };
+		3D2796182DED36CC005D5A1B /* View+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
 		3D2C9E102DE5E031009DAE77 /* EKO-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "EKO-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3D2C9E222DE5E0A0009DAE77 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		3D2C9E242DE5E0A0009DAE77 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -266,6 +270,14 @@
 			path = S3;
 			sourceTree = "<group>";
 		};
+		3D2796142DED3263005D5A1B /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				3D2796152DED3283005D5A1B /* EKOToastMessage.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
 		3D2C9E072DE5E031009DAE77 = {
 			isa = PBXGroup;
 			children = (
@@ -299,6 +311,7 @@
 				3D2C9E302DE5E20A009DAE77 /* Core */,
 				3D2C9E2F2DE5E1F7009DAE77 /* Network */,
 				3D2C9E2E2DE5E175009DAE77 /* Feature */,
+				3D2796142DED3263005D5A1B /* Components */,
 				3D2C9E232DE5E0A0009DAE77 /* Preview Content */,
 			);
 			path = "EKO-iOS";
@@ -359,6 +372,7 @@
 			children = (
 				3D2C9E372DE5F460009DAE77 /* Date+.swift */,
 				3DF325522DE74CB300F9F3F9 /* Font+.swift */,
+				3D2796182DED36CC005D5A1B /* View+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -909,6 +923,7 @@
 				09F425192DEBC2BA00850CDB /* FetchSendFeedbackResponseDTO.swift in Sources */,
 				09F425252DEBC2CB00850CDB /* PatchFeedbackNoteTitleResponseDTO.swift in Sources */,
 				09F425262DEBC2CB00850CDB /* FetchFeedbackNotesResponseDTO.swift in Sources */,
+				3D2796162DED3283005D5A1B /* EKOToastMessage.swift in Sources */,
 				09F425272DEBC2CB00850CDB /* DeleteFeedbackNoteResponseDTO.swift in Sources */,
 				09F425282DEBC2CB00850CDB /* PatchFeedbackNoteFavoriteResponseDTO.swift in Sources */,
 				09F4251E2DEBC2C400850CDB /* PatchNoteTitleRequestDTO.swift in Sources */,
@@ -937,6 +952,7 @@
 				3D2C9EEC2DE5F988009DAE77 /* RecordingResponseSubView.swift in Sources */,
 				3DF3260D2DE895B100F9F3F9 /* UserTargetType.swift in Sources */,
 				3D2C9ED02DE5F696009DAE77 /* RecordingResponseView.swift in Sources */,
+				3D2796192DED36CC005D5A1B /* View+.swift in Sources */,
 				099AD86F2DEBEEDC00CC9717 /* RegisterSubViews.swift in Sources */,
 				3DF327392DE9AA3F00F9F3F9 /* PostStartQuestionRequestDTO.swift in Sources */,
 				3DF327352DE9A9E400F9F3F9 /* NotificationTargetType.swift in Sources */,

--- a/EKO-iOS/EKO-iOS.xcodeproj/project.pbxproj
+++ b/EKO-iOS/EKO-iOS.xcodeproj/project.pbxproj
@@ -32,6 +32,9 @@
 		3D27961B2DED9B13005D5A1B /* EKOToggleIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D27961A2DED9B13005D5A1B /* EKOToggleIndicator.swift */; };
 		3D27961D2DEDA71B005D5A1B /* EKOButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D27961C2DEDA71B005D5A1B /* EKOButton.swift */; };
 		3D27961F2DEDDB86005D5A1B /* EKOEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D27961E2DEDDB86005D5A1B /* EKOEmptyView.swift */; };
+		3D2796212DEDDD1D005D5A1B /* EKOFriendsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D2796202DEDDD1D005D5A1B /* EKOFriendsView.swift */; };
+		3D2796232DEDE28A005D5A1B /* EKOTabSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D2796222DEDE28A005D5A1B /* EKOTabSelector.swift */; };
+		3D2796252DEDE815005D5A1B /* Text+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D2796242DEDE815005D5A1B /* Text+.swift */; };
 		3D2C9E292DE5E0A0009DAE77 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3D2C9E222DE5E0A0009DAE77 /* Preview Assets.xcassets */; };
 		3D2C9E2A2DE5E0A0009DAE77 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3D2C9E242DE5E0A0009DAE77 /* Assets.xcassets */; };
 		3D2C9E2B2DE5E0A0009DAE77 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D2C9E252DE5E0A0009DAE77 /* ContentView.swift */; };
@@ -121,6 +124,9 @@
 		3D27961A2DED9B13005D5A1B /* EKOToggleIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EKOToggleIndicator.swift; sourceTree = "<group>"; };
 		3D27961C2DEDA71B005D5A1B /* EKOButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EKOButton.swift; sourceTree = "<group>"; };
 		3D27961E2DEDDB86005D5A1B /* EKOEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EKOEmptyView.swift; sourceTree = "<group>"; };
+		3D2796202DEDDD1D005D5A1B /* EKOFriendsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EKOFriendsView.swift; sourceTree = "<group>"; };
+		3D2796222DEDE28A005D5A1B /* EKOTabSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EKOTabSelector.swift; sourceTree = "<group>"; };
+		3D2796242DEDE815005D5A1B /* Text+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Text+.swift"; sourceTree = "<group>"; };
 		3D2C9E102DE5E031009DAE77 /* EKO-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "EKO-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3D2C9E222DE5E0A0009DAE77 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		3D2C9E242DE5E0A0009DAE77 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -283,6 +289,8 @@
 				3D27961A2DED9B13005D5A1B /* EKOToggleIndicator.swift */,
 				3D27961C2DEDA71B005D5A1B /* EKOButton.swift */,
 				3D27961E2DEDDB86005D5A1B /* EKOEmptyView.swift */,
+				3D2796202DEDDD1D005D5A1B /* EKOFriendsView.swift */,
+				3D2796222DEDE28A005D5A1B /* EKOTabSelector.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -382,6 +390,7 @@
 				3D2C9E372DE5F460009DAE77 /* Date+.swift */,
 				3DF325522DE74CB300F9F3F9 /* Font+.swift */,
 				3D2796182DED36CC005D5A1B /* View+.swift */,
+				3D2796242DEDE815005D5A1B /* Text+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -954,6 +963,7 @@
 				3D2C9E382DE5F460009DAE77 /* Date+.swift in Sources */,
 				3D2C9EF62DE5FA13009DAE77 /* LearningNoteSubViews.swift in Sources */,
 				3DF327372DE9A9EE00F9F3F9 /* NotificationAPIService.swift in Sources */,
+				3D2796252DEDE815005D5A1B /* Text+.swift in Sources */,
 				3D2C9F0A2DE60F75009DAE77 /* AppRoute.swift in Sources */,
 				099AD8662DEBD24500CC9717 /* AppDelegate.swift in Sources */,
 				3D2C9F042DE5FA85009DAE77 /* AddFriendModel.swift in Sources */,
@@ -967,6 +977,8 @@
 				3D2796192DED36CC005D5A1B /* View+.swift in Sources */,
 				099AD86F2DEBEEDC00CC9717 /* RegisterSubViews.swift in Sources */,
 				3DF327392DE9AA3F00F9F3F9 /* PostStartQuestionRequestDTO.swift in Sources */,
+				3D2796212DEDDD1D005D5A1B /* EKOFriendsView.swift in Sources */,
+				3D2796232DEDE28A005D5A1B /* EKOTabSelector.swift in Sources */,
 				3DF327352DE9A9E400F9F3F9 /* NotificationTargetType.swift in Sources */,
 				099AD8702DEBEEDC00CC9717 /* RegisterView.swift in Sources */,
 				3D2C9EEA2DE5F96C009DAE77 /* RecordingResponseModel.swift in Sources */,

--- a/EKO-iOS/EKO-iOS.xcodeproj/project.pbxproj
+++ b/EKO-iOS/EKO-iOS.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		3D2796192DED36CC005D5A1B /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D2796182DED36CC005D5A1B /* View+.swift */; };
 		3D27961B2DED9B13005D5A1B /* EKOToggleIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D27961A2DED9B13005D5A1B /* EKOToggleIndicator.swift */; };
 		3D27961D2DEDA71B005D5A1B /* EKOButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D27961C2DEDA71B005D5A1B /* EKOButton.swift */; };
+		3D27961F2DEDDB86005D5A1B /* EKOEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D27961E2DEDDB86005D5A1B /* EKOEmptyView.swift */; };
 		3D2C9E292DE5E0A0009DAE77 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3D2C9E222DE5E0A0009DAE77 /* Preview Assets.xcassets */; };
 		3D2C9E2A2DE5E0A0009DAE77 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3D2C9E242DE5E0A0009DAE77 /* Assets.xcassets */; };
 		3D2C9E2B2DE5E0A0009DAE77 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D2C9E252DE5E0A0009DAE77 /* ContentView.swift */; };
@@ -119,6 +120,7 @@
 		3D2796182DED36CC005D5A1B /* View+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
 		3D27961A2DED9B13005D5A1B /* EKOToggleIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EKOToggleIndicator.swift; sourceTree = "<group>"; };
 		3D27961C2DEDA71B005D5A1B /* EKOButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EKOButton.swift; sourceTree = "<group>"; };
+		3D27961E2DEDDB86005D5A1B /* EKOEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EKOEmptyView.swift; sourceTree = "<group>"; };
 		3D2C9E102DE5E031009DAE77 /* EKO-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "EKO-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3D2C9E222DE5E0A0009DAE77 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		3D2C9E242DE5E0A0009DAE77 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -280,6 +282,7 @@
 				3D2796152DED3283005D5A1B /* EKOToastMessage.swift */,
 				3D27961A2DED9B13005D5A1B /* EKOToggleIndicator.swift */,
 				3D27961C2DEDA71B005D5A1B /* EKOButton.swift */,
+				3D27961E2DEDDB86005D5A1B /* EKOEmptyView.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -940,6 +943,7 @@
 				09F4251A2DEBC2BA00850CDB /* PostStartFeedbackResponseDTO.swift in Sources */,
 				3D2C9ED42DE5F6A6009DAE77 /* AddFriendView.swift in Sources */,
 				3DF3255E2DE7FDD400F9F3F9 /* BaseTargetType.swift in Sources */,
+				3D27961F2DEDDB86005D5A1B /* EKOEmptyView.swift in Sources */,
 				3D2C9EFB2DE5FA4B009DAE77 /* ProfileSubViews.swift in Sources */,
 				3D2C9F0C2DE60FCE009DAE77 /* AppCoordinator.swift in Sources */,
 				3DF3272F2DE9A8DC00F9F3F9 /* PostStartQuestionResponseDTO.swift in Sources */,

--- a/EKO-iOS/EKO-iOS/Components/EKOButton.swift
+++ b/EKO-iOS/EKO-iOS/Components/EKOButton.swift
@@ -50,7 +50,6 @@ struct EKOButton: View {
         self.action = action
     }
     
-    
     public var body: some View {
         Button(action: action) {
             Text(type.title)

--- a/EKO-iOS/EKO-iOS/Components/EKOButton.swift
+++ b/EKO-iOS/EKO-iOS/Components/EKOButton.swift
@@ -1,0 +1,72 @@
+//
+//  EKOButton.swift
+//  EKO-iOS
+//
+//  Created by mini on 6/2/25.
+//
+
+import SwiftUI
+
+public enum EKOButtonType {
+    case white, blue
+    
+    var title: String {
+        switch self {
+        case .white: return "내 발음 들려주기"
+        case .blue: return "추가하기"
+        }
+    }
+    
+    var backgroundColor: [Color] {
+        switch self {
+        case .white:
+            return [.mainWhite.opacity(0.9), .mainWhite.opacity(0.5), .mainWhite.opacity(0.9)]
+        case .blue:
+            return [.mainBlue]
+        }
+    }
+    
+    var textColor: Color {
+        switch self {
+        case .white:
+            return .mainBlue
+        case .blue:
+            return .white
+        }
+    }
+}
+
+struct EKOButton: View {
+    @Environment(\.isEnabled) private var isEnabled
+    
+    private let type: EKOButtonType
+    private let action: () -> Void
+        
+    public init(
+        type: EKOButtonType,
+        action: @escaping () -> Void
+    ) {
+        self.type = type
+        self.action = action
+    }
+    
+    
+    public var body: some View {
+        Button(action: action) {
+            Text(type.title)
+                .font(.button01)
+                .padding(.vertical, 16)
+                .padding(.horizontal, 33)
+                .frame(width: 193, height: 55)
+                .foregroundStyle(isEnabled ? type.textColor : .mainWhite)
+                .setupGradientBackground(colors: isEnabled ? type.backgroundColor : [.neutrals4])
+                .clipShape(RoundedRectangle(cornerRadius: 30))
+                .overlay {
+                    if type == .white {
+                        Capsule()
+                            .stroke(Color.mainWhite, lineWidth: 1)
+                    }
+                }
+        }
+    }
+}

--- a/EKO-iOS/EKO-iOS/Components/EKOEmptyView.swift
+++ b/EKO-iOS/EKO-iOS/Components/EKOEmptyView.swift
@@ -30,10 +30,3 @@ struct EKOEmptyView: View {
         }
     }
 }
-
-#Preview {
-    EKOEmptyView(
-        title: "아직 추가된 노트가 없어요.",
-        description: "상대방과 피드백을 주고받으면\n해당 화면에서 학습내역을 확인할 수 있어요."
-    )
-}

--- a/EKO-iOS/EKO-iOS/Components/EKOEmptyView.swift
+++ b/EKO-iOS/EKO-iOS/Components/EKOEmptyView.swift
@@ -1,0 +1,39 @@
+//
+//  EKOEmptyView.swift
+//  EKO-iOS
+//
+//  Created by mini on 6/2/25.
+//
+
+import SwiftUI
+
+struct EKOEmptyView: View {
+    private var title: String
+    private var description: String
+    
+    public init(title: String, description: String) {
+        self.title = title
+        self.description = description
+    }
+    
+    var body: some View {
+        VStack(spacing: 18) {
+            Text(title)
+                .font(.title02)
+                .foregroundStyle(.neutrals2)
+            
+            Text(description)
+                .multilineTextAlignment(.center)
+                .font(.textRegular04)
+                .lineSpacing(4)
+                .foregroundStyle(.neutrals3)
+        }
+    }
+}
+
+#Preview {
+    EKOEmptyView(
+        title: "아직 추가된 노트가 없어요.",
+        description: "상대방과 피드백을 주고받으면\n해당 화면에서 학습내역을 확인할 수 있어요."
+    )
+}

--- a/EKO-iOS/EKO-iOS/Components/EKOFriendsView.swift
+++ b/EKO-iOS/EKO-iOS/Components/EKOFriendsView.swift
@@ -1,0 +1,18 @@
+//
+//  EKOAlert.swift
+//  EKO-iOS
+//
+//  Created by mini on 6/2/25.
+//
+
+import SwiftUI
+
+struct EKOFriendsView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    EKOFriendsView()
+}

--- a/EKO-iOS/EKO-iOS/Components/EKOFriendsView.swift
+++ b/EKO-iOS/EKO-iOS/Components/EKOFriendsView.swift
@@ -1,5 +1,5 @@
 //
-//  EKOAlert.swift
+//  EKOFriendsView.swift
 //  EKO-iOS
 //
 //  Created by mini on 6/2/25.
@@ -7,12 +7,95 @@
 
 import SwiftUI
 
-struct EKOFriendsView: View {
-    var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+public enum EKOFriendsViewType {
+    case request
+    case response
+    
+    var tintColor: Color {
+        switch self {
+        case .request:
+            return .mainOrange
+        case .response:
+            return .mainBlue
+        }
     }
 }
 
-#Preview {
-    EKOFriendsView()
+struct EKOFriendsView: View {
+    private let type: EKOFriendsViewType
+    private let name: String
+    private(set) var isSelected: Bool
+    private(set) var isSended: Bool
+    
+    public init(
+        type: EKOFriendsViewType,
+        name: String,
+        isSelected: Bool = true,
+        isSended: Bool = false
+    ) {
+        self.type = type
+        self.name = name
+        self.isSelected = isSelected
+        self.isSended = isSended
+    }
+    
+    var body: some View {
+        ZStack(alignment: .topTrailing) {
+            if type == .request {
+                Text(name)
+                    .font(.title03)
+                    .foregroundStyle(isSelected ? type.tintColor : .neutrals3)
+                    .padding(.vertical, 6)
+                    .padding(.horizontal, 10)
+                    .background(.mainWhite)
+                    .cornerRadius(15)
+                    .overlay {
+                        Capsule()
+                            .stroke(
+                                isSelected ? type.tintColor : .neutrals3,
+                                lineWidth: 1
+                            )
+                    }
+            } else {
+                Text.styledText(
+                    fullText: "\(name)의 질문",
+                    highlightedText: name,
+                    baseColor: isSelected ? type.tintColor : .neutrals3,
+                    baseFont: .textRegular02,
+                    highlightedColor: isSelected ? type.tintColor : .neutrals3,
+                    highlightedFont: .title03
+                )
+                .padding(.vertical, 6)
+                .padding(.horizontal, 10)
+                .background(.mainWhite)
+                .cornerRadius(15)
+                .overlay {
+                    Capsule()
+                        .stroke(
+                            isSelected ? type.tintColor : .neutrals3,
+                            lineWidth: 1
+                        )
+                }
+            }
+            
+            if isSended {
+                ZStack {
+                    Circle()
+                        .fill(Color.mainWhite)
+                        .frame(width: 20, height: 20)
+                        .overlay(
+                            Circle()
+                                .stroke(isSelected ? type.tintColor : .neutrals3, lineWidth: 1)
+                        )
+
+                    Image(systemName: "paperplane.fill")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 12, height: 12)
+                        .foregroundStyle(isSelected ? type.tintColor : .neutrals3)
+                }
+                .offset(x: 8, y: -8)
+            }
+        }
+    }
 }

--- a/EKO-iOS/EKO-iOS/Components/EKOFriendsView.swift
+++ b/EKO-iOS/EKO-iOS/Components/EKOFriendsView.swift
@@ -30,7 +30,7 @@ struct EKOFriendsView: View {
     public init(
         type: EKOFriendsViewType,
         name: String,
-        isSelected: Bool = true,
+        isSelected: Bool = false,
         isSended: Bool = false
     ) {
         self.type = type

--- a/EKO-iOS/EKO-iOS/Components/EKOTabSelector.swift
+++ b/EKO-iOS/EKO-iOS/Components/EKOTabSelector.swift
@@ -1,0 +1,36 @@
+//
+//  EKOTabSelector.swift
+//  EKO-iOS
+//
+//  Created by mini on 6/2/25.
+//
+
+import SwiftUI
+
+enum EKOTab: String, CaseIterable {
+    case question = "질문하기"
+    case answer = "답변하기"
+}
+
+struct EKOTabSelector: View {
+    @Binding var selected: EKOTab
+    
+    var body: some View {
+        HStack(spacing: 8) {
+            ForEach(EKOTab.allCases, id: \.self) { tab in
+                Button(
+                    action: { selected = tab }
+                ) {
+                    Text(tab.rawValue)
+                        .font(selected == tab ? .title01 : .textRegular01)
+                        .foregroundColor(selected == tab ? .neutrals1 : .neutrals3)
+                }
+                
+                if tab == .question {
+                    Text("|")
+                        .foregroundStyle(.neutrals4)
+                }
+            }
+        }
+    }
+}

--- a/EKO-iOS/EKO-iOS/Components/EKOToastMessage.swift
+++ b/EKO-iOS/EKO-iOS/Components/EKOToastMessage.swift
@@ -1,0 +1,85 @@
+//
+//  EKOToastMessage.swift
+//  EKO-iOS
+//
+//  Created by mini on 6/2/25.
+//
+
+import SwiftUI
+
+public enum EKOToastType {
+    case completeQuestion
+    case completeAnswer
+    case invalidQRCode
+    
+    /// 토스트에 들어갈 유형별 메시지
+    var message: String {
+        switch self {
+        case .completeQuestion, .completeAnswer:
+            return "전송이 완료되었습니다."
+        case .invalidQRCode:
+            return "유효하지 않은 QR입니다."
+        }
+    }
+    
+    /// 토스트에 들어갈 아이콘 (SF Symbols)
+    var iconName: String? {
+        switch self {
+        case .completeQuestion, .completeAnswer:
+            return "paperplane.fill"
+        default: return nil
+        }
+    }
+    
+    /// 토스트 아이콘 색상
+    var iconColor: Color {
+        switch self {
+        case .completeAnswer:
+            return .mainOrange
+        case .completeQuestion:
+            return .mainBlue
+        case .invalidQRCode:
+            return .mainWhite
+        }
+    }
+}
+
+struct EKOToastMessage: View {
+    private let toastType: EKOToastType
+    
+    init(toastType: EKOToastType) {
+        self.toastType = toastType
+    }
+    
+    var body: some View {
+        HStack(spacing: 8) {
+            if let circleImageName = toastType.iconName {
+                Circle()
+                    .frame(width: 15, height: 15)
+                    .foregroundStyle(.mainWhite)
+                    .overlay {
+                        Image(systemName: circleImageName)
+                            .resizable()
+                            .scaledToFit()
+                            .foregroundStyle(toastType.iconColor)
+                            .frame(width: 12, height: 12)
+                    }
+            }
+
+            Text(toastType.message)
+                .font(.textSemiBold02)
+                .foregroundColor(.neutrals2)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .setupGradientBackground(colors: [
+            .mainWhite.opacity(0.8), .mainWhite.opacity(0.5)
+        ])
+        .cornerRadius(28)
+        .overlay(
+            RoundedRectangle(cornerRadius: 28)
+                .stroke(Color.white.opacity(0.3), lineWidth: 0.5)
+        )
+        .shadow(color: .black.opacity(0.05), radius: 1, x: 0, y: 1)
+    }
+}

--- a/EKO-iOS/EKO-iOS/Components/EKOToggleIndicator.swift
+++ b/EKO-iOS/EKO-iOS/Components/EKOToggleIndicator.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-enum ToggleType {
+enum EKOToggleType {
     case downDirection, upDirection
     
     var title: String {
@@ -25,10 +25,10 @@ enum ToggleType {
     }
 }
 
-struct ToggleItemView: View {
-    private let type: ToggleType
+struct EKOToggleIndicator: View {
+    private let type: EKOToggleType
     
-    init(type: ToggleType) {
+    init(type: EKOToggleType) {
         self.type = type
     }
     

--- a/EKO-iOS/EKO-iOS/Components/EKOToggleIndicator.swift
+++ b/EKO-iOS/EKO-iOS/Components/EKOToggleIndicator.swift
@@ -1,0 +1,44 @@
+//
+//  EKOToggleIndicator.swift
+//  EKO-iOS
+//
+//  Created by mini on 6/2/25.
+//
+
+import SwiftUI
+
+enum ToggleType {
+    case downDirection, upDirection
+    
+    var title: String {
+        switch self {
+        case .downDirection: return "Note"
+        case .upDirection: return "Record"
+        }
+    }
+    
+    var icon: Image {
+        switch self {
+        case .downDirection: return Image(.toggleDown)
+        case .upDirection: return Image(.toggleUp)
+        }
+    }
+}
+
+struct ToggleItemView: View {
+    private let type: ToggleType
+    
+    init(type: ToggleType) {
+        self.type = type
+    }
+    
+    var body: some View {
+        VStack(spacing: 4) {
+            Text(type.title)
+                .font(.textRegular05)
+                .foregroundColor(.neutrals3)
+            
+            type.icon
+        }
+    }
+}

--- a/EKO-iOS/EKO-iOS/Core/Extensions/Text+.swift
+++ b/EKO-iOS/EKO-iOS/Core/Extensions/Text+.swift
@@ -1,0 +1,37 @@
+//
+//  Text+.swift
+//  EKO-iOS
+//
+//  Created by mini on 6/2/25.
+//
+
+import SwiftUI
+
+extension Text {
+    /// 특정 문자열을 다른 스타일로 꾸미는 함수
+    static func styledText(
+        fullText: String,
+        highlightedText: String,
+        baseColor: Color,
+        baseFont: Font,
+        highlightedColor: Color,
+        highlightedFont: Font
+    ) -> Text {
+        let parts = fullText.components(separatedBy: highlightedText)
+        var styled = Text("")
+        
+        for (index, partText) in parts.enumerated() {
+            styled = styled + Text(partText)
+                .foregroundStyle(baseColor)
+                .font(baseFont)
+            
+            if index < parts.count - 1 {
+                styled = styled + Text(highlightedText)
+                    .foregroundStyle(highlightedColor)
+                    .font(highlightedFont)
+            }
+        }
+
+        return styled
+    }
+}

--- a/EKO-iOS/EKO-iOS/Core/Extensions/View+.swift
+++ b/EKO-iOS/EKO-iOS/Core/Extensions/View+.swift
@@ -1,0 +1,51 @@
+//
+//  View+.swift
+//  EKO-iOS
+//
+//  Created by mini on 6/2/25.
+//
+
+import SwiftUI
+
+extension View {
+    /// View의 배경색을 그라디언트 색상을 적용해서 만들 수 있도록 도와주는 Extension Method
+    func setupGradientBackground(colors: [Color]) -> some View {
+        self.background(
+            LinearGradient(
+                gradient: Gradient(colors: colors),
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        )
+    }
+    
+    /// EKOToastMessage를 원하는 시간동안 보였다가 자동으로 사라지도록 만드는 Extension Method
+    func showToast(
+        toastType: EKOToastType?,
+        isShowing: Binding<Bool>,
+        bottomPadding: CGFloat,
+        duration: TimeInterval = 3.0
+    ) -> some View {
+        ZStack {
+            self
+
+            if isShowing.wrappedValue, let type = toastType {
+                VStack {
+                    Spacer()
+
+                    EKOToastMessage(toastType: type)
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                        .padding(.bottom, bottomPadding)
+                }
+                .onAppear {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + duration) {
+                        withAnimation {
+                            isShowing.wrappedValue = false
+                        }
+                    }
+                }
+            }
+        }
+        .animation(.easeInOut, value: isShowing.wrappedValue)
+    }
+}

--- a/EKO-iOS/EKO-iOS/Core/Resources/Assets/Assets.xcassets/toggle_down.imageset/Contents.json
+++ b/EKO-iOS/EKO-iOS/Core/Resources/Assets/Assets.xcassets/toggle_down.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "toggle_down.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/EKO-iOS/EKO-iOS/Core/Resources/Assets/Assets.xcassets/toggle_down.imageset/toggle_down.svg
+++ b/EKO-iOS/EKO-iOS/Core/Resources/Assets/Assets.xcassets/toggle_down.imageset/toggle_down.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="10" viewBox="0 0 16 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2 2L8 8L14 2" stroke="#333333" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/EKO-iOS/EKO-iOS/Core/Resources/Assets/Assets.xcassets/toggle_up.imageset/Contents.json
+++ b/EKO-iOS/EKO-iOS/Core/Resources/Assets/Assets.xcassets/toggle_up.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "toggle_up.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/EKO-iOS/EKO-iOS/Core/Resources/Assets/Assets.xcassets/toggle_up.imageset/toggle_up.svg
+++ b/EKO-iOS/EKO-iOS/Core/Resources/Assets/Assets.xcassets/toggle_up.imageset/toggle_up.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="10" viewBox="0 0 16 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2 8L8 2L14 8" stroke="#333333" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/EKO-iOS/EKO-iOS/Core/Resources/Assets/Colors.xcassets/mainOrange.colorset/Contents.json
+++ b/EKO-iOS/EKO-iOS/Core/Resources/Assets/Colors.xcassets/mainOrange.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x1A",
-          "green" : "0x82",
-          "red" : "0xF1"
+          "blue" : "0x42",
+          "green" : "0xA3",
+          "red" : "0xFE"
         }
       },
       "idiom" : "universal"

--- a/EKO-iOS/EKO-iOS/Core/Resources/Assets/Colors.xcassets/supBlue4.colorset/Contents.json
+++ b/EKO-iOS/EKO-iOS/Core/Resources/Assets/Colors.xcassets/supBlue4.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF8",
+          "green" : "0xF4",
+          "red" : "0xEB"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/EKO-iOS/EKO-iOS/Core/Resources/Assets/Colors.xcassets/supOrange1.colorset/Contents.json
+++ b/EKO-iOS/EKO-iOS/Core/Resources/Assets/Colors.xcassets/supOrange1.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x49",
-          "green" : "0x9D",
-          "red" : "0xF5"
+          "blue" : "0x8F",
+          "green" : "0xCD",
+          "red" : "0xFF"
         }
       },
       "idiom" : "universal"

--- a/EKO-iOS/EKO-iOS/Core/Resources/Assets/Colors.xcassets/supOrange2.colorset/Contents.json
+++ b/EKO-iOS/EKO-iOS/Core/Resources/Assets/Colors.xcassets/supOrange2.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x8A",
-          "green" : "0xC2",
-          "red" : "0xFA"
+          "blue" : "0xB6",
+          "green" : "0xE0",
+          "red" : "0xFF"
         }
       },
       "idiom" : "universal"

--- a/EKO-iOS/EKO-iOS/Core/Resources/Assets/Colors.xcassets/supOrange3.colorset/Contents.json
+++ b/EKO-iOS/EKO-iOS/Core/Resources/Assets/Colors.xcassets/supOrange3.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xB2",
-          "green" : "0xD8",
-          "red" : "0xFB"
+          "blue" : "0xE7",
+          "green" : "0xF2",
+          "red" : "0xFF"
         }
       },
       "idiom" : "universal"


### PR DESCRIPTION
## ✨ 해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #24 

## 🔍 PR Content
<!-- 작업 내용 설명 -->
재사용 가능한 UI Component를 제작했습니다.
기본 Component를 사용하는 Menu, Alert는 제작하지 않았고 / 두 개 이상의 화면에서 재사용 가능한 화면만 만든점 양해 부탁합니다 ~

자세한 사용법에 대한 내용은 [노션 페이지 - Mini가 말아주는 재사용 Components 사용법](https://tough-war-2ac.notion.site/Mini-Components-206212ca553f809ea337e618404b9c02?source=copy_link)을 참고해주시와요 ~~

- EKOToastMessage : 토스트 메시지 (질문하기, 답변하기, 친구추가 뷰)
- EKOToggleIndicator : 토글같이 생긴 IndicatorView (질문하기, 학습노트 뷰)
- EKOTabSelector : 메인화면 좌측 상단 커스텀 탭바 (질문하기, 답변하기 뷰)
- EKOButton : 버튼 (답변하기, 친구추가 뷰)
- EKOEmptyView : 엠티뷰 (답변하기, 학습노트 뷰)
- EKOFriendsView : 친구 목록 셀 (질문하기, 답변하기 뷰)

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
